### PR TITLE
Implemented backwards-compatibility with 'normal'

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -739,14 +739,14 @@ html[it-player-color='white'] {
     --it-player-color: #fff;
 }
 
-html[it-player-color]:not([it-player-color='red']) .ytp-play-progress,
-html[it-player-color]:not([it-player-color='red']) .ytp-scrubber-button,
-html[it-player-color]:not([it-player-color='red']) .ytp-menuitem[aria-checked=true] .ytp-menuitem-toggle-checkbox,
-html[it-player-color]:not([it-player-color='red']) .ytp-settings-button.ytp-hd-quality-badge:after {
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) .ytp-play-progress,
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) .ytp-scrubber-button,
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) .ytp-menuitem[aria-checked=true] .ytp-menuitem-toggle-checkbox,
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) .ytp-settings-button.ytp-hd-quality-badge:after {
     background-color: var(--it-player-color) !important;
 }
 
-html[it-player-color]:not([it-player-color='red']) .ytp-swatch-color {
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) .ytp-swatch-color {
     color: var(--it-player-color) !important;
 }
 


### PR DESCRIPTION
Fixes #794 - I found that the cause was that an older version of IT had used the value "normal" for the player color, but newer versions did not have support for that value, leading to the player bar (And all the other elements which are affected) being greyed out. This simply adds support for that value on the CSS side.