### PR TITLE
Remove reference to build.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Big thanks ❤️ to our [contributors](https://github.com/ImprovedTube/Improved
 
 ## 🔧 Install from source
 
-1. Download & extract the [latest release](https://github.com/ImprovedTube/ImprovedTube/releases/latest)  *(or download the repo & run the [build.py](https://github.com/code4charity/YouTube-Extension/wiki/build.py)!)*
+1. Download & extract the [latest release](https://github.com/ImprovedTube/ImprovedTube/releases/latest)
 
  -  **Chromium[ ](https://github.com/chromium/chromium) / Brave[ ](https://github.com/brave/brave) / Vivaldi / ...**
 


### PR DESCRIPTION
The file was removed in below commit and caused, at least myself, a moment of confusion for how to run things

eb4530677b13d18ae3cce855802782f9fb3a447a