### PR TITLE
Added option to hide controls & shortcut to toggle them

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -737,6 +737,9 @@
     "todayAt": {
         "message": "Today at"
     },
+    "toggleAutoplay": {
+        "message": "Toggle autoplay"
+    },
     "toggleCards": {
         "message": "Toggle cards"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -344,6 +344,9 @@
     "hideCards": {
         "message": "Hide cards"
     },
+    "hideControls": {
+        "message": "Hide player controls"
+    },
     "hideDetails": {
         "message": "Hide details"
     },
@@ -737,11 +740,11 @@
     "todayAt": {
         "message": "Today at"
     },
-    "toggleAutoplay": {
-        "message": "Toggle autoplay"
-    },
     "toggleCards": {
         "message": "Toggle cards"
+    },
+    "toggleControls": {
+        "message": "Toggle player controls"
     },
     "topChat": {
         "message": "Top chat"

--- a/popup.js
+++ b/popup.js
@@ -2715,6 +2715,10 @@ Menu.main.section.shortcuts = {
             type: 'shortcut',
             label: 'stop'
         },
+        shortcut_toggle_autoplay: {
+            type: 'shortcut',
+            label: 'toggleAutoplay'
+        },
         shortcut_next_video: {
             type: 'shortcut',
             label: 'nextVideo',

--- a/popup.js
+++ b/popup.js
@@ -2589,6 +2589,11 @@ Menu.main.section.player = {
         player_popup_button: {
             type: 'switch',
             label: 'popupPlayer'
+        },
+        player_hide_controls: {
+            type: 'switch',
+            label: 'hideControls',
+            value: false
         }
     }
 };
@@ -2700,6 +2705,10 @@ Menu.main.section.shortcuts = {
     player_section: {
         type: 'section',
 
+        shortcut_toggle_controls: {
+            type: 'shortcut',
+            label: 'toggleControls'
+        },
         shortcut_picture_in_picture: {
             type: 'shortcut',
             label: 'pictureInPicture'
@@ -2714,10 +2723,6 @@ Menu.main.section.shortcuts = {
         shortcut_stop: {
             type: 'shortcut',
             label: 'stop'
-        },
-        shortcut_toggle_autoplay: {
-            type: 'shortcut',
-            label: 'toggleAutoplay'
         },
         shortcut_next_video: {
             type: 'shortcut',

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -99,9 +99,9 @@ ImprovedTube.youtubeHomePage = function() {
         option === '/playlist?list=WL'
     ) {
         var node_list = document.querySelectorAll(`
-            	a[href="/"]:not([role=tablist]),
-            	a[href="https://www.youtube.com/"]:not([role=tablist]),
-            	a[it-origin="/"]:not([role=tablist])
+                a[href="/"]:not([role=tablist]),
+                a[href="https://www.youtube.com/"]:not([role=tablist]),
+                a[it-origin="/"]:not([role=tablist])
             `);
 
         for (var i = 0, l = node_list.length; i < l; i++) {
@@ -2249,10 +2249,10 @@ ImprovedTube.shortcuts = function() {
             },
             shortcut_toggle_autoplay: function() {
                 var toggle = document.querySelector('.ytp-autonav-toggle-button'),
-					attribute = toggle.getAttribute('aria-checked') === 'true';
+                    attribute = toggle.getAttribute('aria-checked') === 'true';
 
                 if (toggle) {
-					toggle.click();
+                    toggle.click();
                 }
             },
             shortcut_next_video: function() {

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -2247,6 +2247,14 @@ ImprovedTube.shortcuts = function() {
                     player.stopVideo();
                 }
             },
+            shortcut_toggle_autoplay: function() {
+                var toggle = document.querySelector('.ytp-autonav-toggle-button'),
+					attribute = toggle.getAttribute('aria-checked') === 'true';
+
+                if (toggle) {
+					toggle.click();
+                }
+            },
             shortcut_next_video: function() {
                 var player = document.querySelector('#movie_player');
 

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -48,6 +48,7 @@
   4.16 Rotate
   4.17 Popup player
   4.18 Force SDR
+  4.19 Hide controls
 5.0 Playlist
   5.1 Up next autoplay
   5.2 Reverse
@@ -1878,6 +1879,23 @@ ImprovedTube.playerSDR = function() {
 };
 
 /*------------------------------------------------------------------------------
+4.19 Hide controls
+------------------------------------------------------------------------------*/
+
+ImprovedTube.playerControls = function() {
+    if (!node) {
+		var node = document.querySelector('.html5-video-player');
+	}
+
+    if (this.storage.player_hide_controls === true) {
+        node.hideControls();
+    }
+    else {
+        node.showControls();
+    }
+};
+
+/*------------------------------------------------------------------------------
 5.0 PLAYLIST
 --------------------------------------------------------------------------------
 TODO: CONNECT & TEST
@@ -2229,6 +2247,20 @@ ImprovedTube.shortcuts = function() {
                     video.requestPictureInPicture();
                 }
             },
+            shortcut_toggle_controls: function() {
+                var player = document.querySelector('.html5-video-player');
+
+                if (player && player.hideControls && player.showControls) {
+                	ImprovedTube.storage.player_hide_controls = !ImprovedTube.storage.player_hide_controls;
+
+                    if (ImprovedTube.storage.player_hide_controls === true) {
+                        player.hideControls();
+                    }
+                    else {
+                    	player.showControls();
+                    }
+                }
+            },
             shortcut_play_pause: function() {
                 var video = document.querySelector('#movie_player video');
 
@@ -2245,14 +2277,6 @@ ImprovedTube.shortcuts = function() {
 
                 if (player) {
                     player.stopVideo();
-                }
-            },
-            shortcut_toggle_autoplay: function() {
-                var toggle = document.querySelector('.ytp-autonav-toggle-button'),
-                    attribute = toggle.getAttribute('aria-checked') === 'true';
-
-                if (toggle) {
-                    toggle.click();
                 }
             },
             shortcut_next_video: function() {
@@ -3017,6 +3041,7 @@ ImprovedTube.videoPageUpdate = function() {
         this.playerRepeatButton();
         this.playerRotateButton();
         this.playerPopupButton();
+        this.playerControls();
 
         this.playlistUpNextAutoplay();
         this.playlistReverse();


### PR DESCRIPTION
+ Option "Hide player controls" will permanently hide the YouTube player overlay until the option is disabled (or toggled via shortcut)
+ New shortcut that allows toggling of the player controls while watching a video.