### PR TITLE
Added option to hide thumbnail overlays

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -368,6 +368,9 @@
     "hideScrollForDetails": {
         "message": "Hide «Scroll for details»"
     },
+    "hideThumbnailOverlay": {
+        "message": "Hide buttons on thumbnails"
+    },
     "hideViewsCount": {
         "message": "Hide views count"
     },

--- a/popup.js
+++ b/popup.js
@@ -1592,6 +1592,11 @@ Menu.main.section.general = {
             type: 'switch',
             label: 'hideAnimatedThumbnails',
             tags: 'preview'
+        },
+        hide_thumbnail_overlay: {
+            type: 'switch',
+            label: 'hideThumbnailOverlay',
+            tags: 'preview'
         }
     }
 };

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -11,6 +11,7 @@
   1.5 Mark watched videos
   1.6 Only one player instance playing
   1.7 HD thumbnails
+  1.8 Hide thumbnail overlay
 2.0 Appearance
   2.1 Player
     2.1.1 Forced theater mode
@@ -99,9 +100,9 @@ ImprovedTube.youtubeHomePage = function() {
         option === '/playlist?list=WL'
     ) {
         var node_list = document.querySelectorAll(`
-            	a[href="/"]:not([role=tablist]),
-            	a[href="https://www.youtube.com/"]:not([role=tablist]),
-            	a[it-origin="/"]:not([role=tablist])
+                a[href="/"]:not([role=tablist]),
+                a[href="https://www.youtube.com/"]:not([role=tablist]),
+                a[it-origin="/"]:not([role=tablist])
             `);
 
         for (var i = 0, l = node_list.length; i < l; i++) {
@@ -383,6 +384,20 @@ ImprovedTube.hdThumbnails = function() {
             if (images[i].dataset.defaultSrc) {
                 images[i].src = images[i].dataset.defaultSrc;
             }
+        }
+    }
+};
+
+/*------------------------------------------------------------------------------
+1.8 HIDE THUMBNAIL OVERLAY
+------------------------------------------------------------------------------*/
+
+ImprovedTube.hideThumbnailOverlay = function() {
+    if (this.storage.hide_thumbnail_overlay === true) {
+        var overlays = document.querySelectorAll('#hover-overlays');
+
+        for (var i = 0, l = overlays.length; i < l; i++) {
+            overlays[i].remove();
         }
     }
 };
@@ -2981,6 +2996,7 @@ ImprovedTube.pageUpdateListener = function() {
         ImprovedTube.collapseOfSubscriptionSections();
         ImprovedTube.markWatchedVideos();
         ImprovedTube.hdThumbnails();
+        ImprovedTube.hideThumbnailOverlay();
 
         ImprovedTube.channelDefaultTab();
 
@@ -3074,6 +3090,7 @@ ImprovedTube.DOMContentLoaded = function() {
         ImprovedTube.confirmationBeforeClosing();
         ImprovedTube.markWatchedVideos();
         ImprovedTube.hdThumbnails();
+        ImprovedTube.hideThumbnailOverlay();
 
         ImprovedTube.channelDefaultTab();
 
@@ -3303,6 +3320,7 @@ ImprovedTube.init = function() {
 
     window.addEventListener('load', function() {
         ImprovedTube.hdThumbnails();
+        ImprovedTube.hideThumbnailOverlay();
         ImprovedTube.channelDefaultTab();
     });
 };

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -397,7 +397,7 @@ ImprovedTube.hideThumbnailOverlay = function() {
         var overlays = document.querySelectorAll('#hover-overlays');
 
         for (var i = 0, l = overlays.length; i < l; i++) {
-            overlays[i].remove();
+            overlays[i].style.display = "none";
         }
     }
 };


### PR DESCRIPTION
+ Added an option that allows hiding (removal) of the buttons overlaid on thumbnails. See #771.

(Now using CSS to remove them rather than `remove()`)