### PR TITLE
fix: Small codebase refactor to fix shortcuts for DOM buttons

### DIFF
--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -2224,6 +2224,7 @@ ImprovedTube.shortcuts = function() {
                 // if there is no player the most likely we are not in watch page?
                 if (!player) return;
                 printError("Shortcuts", `Can't find ${button} button in visible DOM`);
+                return;
             }
             visibleButton.click();
         };

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -2164,6 +2164,10 @@ TODO: Use keyboard library
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcuts = function() {
+    const printError = (section, message) => {
+        console.error(`%c[Improve YouTube!] ${section}%c – ${message}`, "font-weight: bold; color: red;", "font-weight: unset; color: unset;");
+    }
+    
     var self = this,
         /** @type {Partial<Pick<KeyboardEvent, "keyCode" | "altKey" | "shiftKey" | "ctrlKey" | "metaKey">>} */
         pressedKey = {},
@@ -2202,6 +2206,27 @@ ImprovedTube.shortcuts = function() {
         if (document.activeElement && ['EMBED', 'INPUT', 'OBJECT', 'TEXTAREA', 'IFRAME'].indexOf(document.activeElement.tagName) !== -1 || event.target.isContentEditable) {
             return;
         }
+
+        const buttonsSelectors = {
+            like: "#menu #top-level-buttons-computed ytd-toggle-button-renderer:nth-child(1) a",
+            dislike: "#menu #top-level-buttons-computed ytd-toggle-button-renderer:nth-child(2) a",
+            subscribe: "#subscribe-button a"
+        };
+        const pressButton = (
+            /** @type {keyof typeof buttonsSelectors} */
+            button
+        ) => {
+            const elems = document.querySelectorAll(buttonsSelectors[button]);
+            const visibleButton = [].find.call(elems, elem => elem.offsetParent !== null);
+            // TODO throw natural error with `cause`
+            if (!visibleButton) {
+                const player = document.querySelector('#movie_player');
+                // if there is no player the most likely we are not in watch page?
+                if (!player) return;
+                printError("Shortcuts", `Can't find ${button} button in visible DOM`);
+            }
+            visibleButton.click();
+        };
 
         var features = {
             shortcut_auto: function() {
@@ -2482,25 +2507,14 @@ ImprovedTube.shortcuts = function() {
                 }
             },
             shortcut_like_shortcut: function() {
-                var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer')[0]);
-
-                if (like) {
-                    like.click();
-                }
+                pressButton("like")
             },
             shortcut_dislike_shortcut: function() {
-                var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer')[1]);
-
-                if (like) {
-                    like.click();
-                }
+                pressButton("dislike")
             },
             shortcut_subscribe: function() {
-                var button = document.querySelector('#subscribe-button .ytd-subscribe-button-renderer');
+                pressButton("subscribe")
 
-                if (button) {
-                    button.click();
-                }
             },
             shortcut_dark_theme: function() {
                 if (document.documentElement.hasAttribute('dark')) {

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -2160,12 +2160,15 @@ ImprovedTube.channelDefaultTab = function() {
 7.0 SHORTCUTS
 --------------------------------------------------------------------------------
 TODO: CONNECT & TEST
+TODO: Use keyboard library
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcuts = function() {
     var self = this,
-        keys = {},
+        /** @type {Partial<Pick<KeyboardEvent, "keyCode" | "altKey" | "shiftKey" | "ctrlKey" | "metaKey">>} */
+        pressedKey = {},
         wheel = 0,
+        /** Is cursor under the video element */
         hover = false,
         status_timer;
 
@@ -2192,9 +2195,12 @@ ImprovedTube.shortcuts = function() {
         }, 500);
     }
 
-    function start(type = 'keys') {
+    /**
+     * @param {KeyboardEvent | WheelEvent} event 
+     */
+    function trigger(event) {
         if (document.activeElement && ['EMBED', 'INPUT', 'OBJECT', 'TEXTAREA', 'IFRAME'].indexOf(document.activeElement.tagName) !== -1 || event.target.isContentEditable) {
-            return false;
+            return;
         }
 
         var features = {
@@ -2556,27 +2562,27 @@ ImprovedTube.shortcuts = function() {
             }
         };
 
-        for (var i in features) {
-            if (self.isset(self.storage[i])) {
-                var data = JSON.parse(self.storage[i]) || {};
+        for (var featureName in features) {
+            if (self.isset(self.storage[featureName])) {
+                var data = JSON.parse(self.storage[featureName]) || {};
 
                 if (
-                    (data.keyCode === keys.keyCode || !self.isset(data.keyCode)) &&
-                    (data.shiftKey === keys.shiftKey || !self.isset(data.shiftKey)) &&
-                    (data.ctrlKey === keys.ctrlKey || !self.isset(data.ctrlKey)) &&
-                    (data.altKey === keys.altKey || !self.isset(data.altKey)) &&
+                    (data.keyCode === pressedKey.keyCode || !self.isset(data.keyCode)) &&
+                    (data.shiftKey === pressedKey.shiftKey || !self.isset(data.shiftKey)) &&
+                    (data.ctrlKey === pressedKey.ctrlKey || !self.isset(data.ctrlKey)) &&
+                    (data.altKey === pressedKey.altKey || !self.isset(data.altKey)) &&
                     ((data.wheel > 0) === (wheel > 0) || !self.isset(data.wheel)) &&
-                    ((hover === true && (data.wheel > 0) === (wheel > 0) && Object.keys(keys).length === 0 && keys.constructor === Object) || (self.isset(data.key) || self.isset(data.altKey) || self.isset(data.ctrlKey)))
+                    ((hover === true && (data.wheel > 0) === (wheel > 0) && Object.keys(pressedKey).length === 0) || (self.isset(data.key) || self.isset(data.altKey) || self.isset(data.ctrlKey)))
                 ) {
-                    if (type === 'wheel' && self.isset(data.wheel) || type === 'keys') {
+                    if (event.type === 'wheel' && self.isset(data.wheel) || event.type === 'keydown') {
                         event.preventDefault();
                         event.stopPropagation();
                     }
 
-                    features[i]();
-
-                    if (type === 'wheel' && self.isset(data.wheel) || type === 'keys') {
-                        return false;
+                    features[featureName]();
+                    
+                    if (event.type === 'wheel' && self.isset(data.wheel) || event.type === 'keydown') {
+                        return;
                     }
                 }
             }
@@ -2589,19 +2595,14 @@ ImprovedTube.shortcuts = function() {
     -------------------------------------------------------------------------*/
 
     window.addEventListener('keydown', function(event) {
-        keys = {
-            key: event.key,
-            keyCode: event.keyCode,
-            shiftKey: event.shiftKey,
-            ctrlKey: event.ctrlKey,
-            altKey: event.altKey
-        };
+        // shortcut will be fired again and again until the key is released. To get rid of that: if (event.repeat) return;
+        pressedKey = event;
 
-        start();
+        trigger(event);
     }, true);
 
     window.addEventListener('keyup', function(event) {
-        keys = {};
+        pressedKey = {};
     }, true);
 
 
@@ -2614,8 +2615,9 @@ ImprovedTube.shortcuts = function() {
 
         hover = false;
 
-        for (var i = 0, l = path.length; i < l; i++) {
-            if (path[i].classList && path[i].classList.contains('html5-video-player')) {
+        // TODO: refactor with elem.target.closest(".html5-video-player")
+        for (let elem of path) {
+            if (elem.classList && elem.classList.contains('html5-video-player')) {
                 hover = true;
             }
         }
@@ -2627,7 +2629,7 @@ ImprovedTube.shortcuts = function() {
     window.addEventListener('wheel', function(event) {
         wheel = event.deltaY;
 
-        start('wheel');
+        trigger(event);
     }, {
         passive: false,
         capture: true


### PR DESCRIPTION
Sorry for the latency, I'm really slow because its extremely hot.

I can see that codebase doesn't use JSDoc but I have added some types to simplify refactoring and ensure that it won't break anything. Trust me, typed codebases are awesome!

Also, I have introduced a helper `printError` that shows display errors in that form: 
![image](https://user-images.githubusercontent.com/78976241/125435410-f9156a37-fe7a-4248-b59f-68c214585004.png)

Hope you like that! It is more useful than silence.

The main purpose of this PR is to fix (and dynamically find **only visible DOM buttons**) and click them (usually they're `<a>`):
![image](https://user-images.githubusercontent.com/78976241/125435650-fa463ba6-54f2-45bd-b0cb-60e83afdb57b.png)

As @Michael82548 pointed out YouTube just changed the page layout. Sometimes, Google can introduce A/B experiments or just leave old page parts right in the DOM! In this case upper DOM is hidden for the user, but actually accessible via JS (selectors). This is how it looks like without `hidden` attribute:

![image](https://user-images.githubusercontent.com/78976241/125436450-bacd768e-2e62-4ca8-8c98-b40b247a5188.png)

Also, that's why YouTube is so **slow**, because the DOM is extremely heavy and inefficient. One of the forward steps could be to completely rewrite YouTube frontend, this also will allow usage of custom themes, like arwes.

closes #971