### PR TITLE
Fixed skip overlay not working

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -943,7 +943,7 @@ html[it-hide-gradient-bottom=true] .ytp-gradient-bottom {
 2.2.11 Skip overlay
 ------------------------------------------------------------------------------*/
 
-html[it-player-hide-skip-overlay=true] .ytp-doubletap-ui
+html[it-player-hide-skip-overlay=true] .ytp-doubletap-ui, .ytp-doubletap-ui-legacy
 {
     visibility: hidden;
 }


### PR DESCRIPTION
ImprovedTube not hiding the skip overlay as YouTube change the class name from ytp-doubletap-ui to ytp-doubletap-ui-legacy.