### PR TITLE
Sync player volume between local and session on volume shortcuts

### DIFF
--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -3528,6 +3528,7 @@ ImprovedTube.shortcutIncreaseVolume = function () {
                 creation: Date.now()
             })
         })
+        sessionStorage['yt-player-volume'] = localStorage['yt-player-volume']
 
         this.showStatus(player.getVolume());
     }
@@ -3552,6 +3553,7 @@ ImprovedTube.shortcutDecreaseVolume = function () {
                 creation: Date.now()
             })
         })
+        sessionStorage['yt-player-volume'] = localStorage['yt-player-volume']
 
         this.showStatus(player.getVolume());
     }


### PR DESCRIPTION
Looks like youtube player also sets session storage volume if you
increase it manually.