### PR TITLE
BUG/Forced_Theater_Mode

### DIFF
--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -1164,10 +1164,15 @@ ImprovedTube.playerSize = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.forcedTheaterMode = function () {
+    var button = this.elements.player.querySelector('button.ytp-size-button');
     if (window.self === window.top && this.storage.forced_theater_mode === true) {
-        var button = this.elements.player.querySelector('button.ytp-size-button');
-
         if (button && this.elements.ytd_watch.theater === false) {
+            setTimeout(function() {
+                button.click();
+            }, 200);
+        }
+    } else if(window.self === window.top && this.storage.forced_theater_mode === false) {
+        if (button && this.elements.ytd_watch.theater === true) {
             setTimeout(function() {
                 button.click();
             }, 200);


### PR DESCRIPTION
BUG : Forced Theater Mode
Once we click on the ForceTheaterMode its enable the theater mode, when we un-check its not reverting back to the normal mode.  -- 1

TheaterMode is enabled on loading youtube, if you disable theatermode and reload the page also it won't back to normal. Once ForceMode is enable its keep on set to True if you make it false also.

In this fix it has been resolved, attached the screenshots for reference.

![After_Fix_TheaterMode_Disabled](https://user-images.githubusercontent.com/30232236/140299691-2f516e4b-544f-4a3c-8613-9e47d2044e3d.png)
![After_Fix_TheaterMode_Enabled](https://user-images.githubusercontent.com/30232236/140299696-bff8953f-8d9c-45ed-8ecb-5179e2fa8094.png)
![Before_Fix_Theater_Mode_Disabled](https://user-images.githubusercontent.com/30232236/140299697-e0e0b25c-a6ed-4de7-8c8c-cc114c275cda.png)
