### PR TITLE
Update player.js playerQualityWithoutFocus breaks on switching tabs

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -405,10 +405,13 @@ ImprovedTube.playerQualityWithoutFocus = function () {
 		if (this.focus) {
 			if (ImprovedTube.qualityBeforeBlur) {
 				ImprovedTube.playerQuality(ImprovedTube.qualityBeforeBlur);
+				ImprovedTube.qualityBeforeBlur = undefined;
 			}
 		} else {
 			if (!ImprovedTube.elements.video.paused) {
-				ImprovedTube.qualityBeforeBlur = player.getPlaybackQuality();
+				if (!ImprovedTube.qualityBeforeBlur) {
+					ImprovedTube.qualityBeforeBlur = player.getPlaybackQuality();
+				}
 				ImprovedTube.playerQuality(qualityWithoutFocus);
 			}
 		}


### PR DESCRIPTION
https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/background.js#L179-L202

sends additional second blur message on tab switch

this https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/js%26css/web-accessible/www.youtube.com/player.js#L411
sets qualityBeforeBlur again when already minimized, this time to this.storage.player_quality_without_focus. After rocusing back video quality is "restored" to qualityBeforeBlur  === this.storage.player_quality_without_focus.

background.js is sending second blur event. Its sending multiple ones when whole browser is minimized for example, or tab switched. Dont know why and if its needed. Definitely sending events to tabs where extension is not running is not good.