### PR TITLE
Fix issue #2587: playback speed shortcut works when manually saved or reset by user 

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2386,6 +2386,8 @@ satus.components.shortcut = function (component, skeleton) {
 							component.data = component.skeleton.value || {};
 							satus.storage.remove(component.storage.key);
 
+							component.storage.value = component.data;
+
 							component.render(component.valueElement);
 
 							this.parentNode.parentNode.parentNode.close();

--- a/menu/skeleton-parts/shortcuts.js
+++ b/menu/skeleton-parts/shortcuts.js
@@ -143,9 +143,10 @@ extension.skeleton.main.layers.section.shortcuts = {
 									component: 'shortcut',
 									text: 'increasePlaybackSpeed',
 									value: {
+										shift: true,
 										keys: {
-											188: {
-												key: '<'
+											190: {
+												key: '>'
 											}
 										}
 									}
@@ -154,9 +155,10 @@ extension.skeleton.main.layers.section.shortcuts = {
 									component: 'shortcut',
 									text: 'decreasePlaybackSpeed',
 									value: {
+										shift: true,
 										keys: {
-											190: {
-												key: '>'
+											188: {
+												key: '<'
 											}
 										}
 									}
@@ -164,6 +166,15 @@ extension.skeleton.main.layers.section.shortcuts = {
 								shortcut_reset_playback_speed: {
 									component: 'shortcut',
 									text: 'reset'
+								},
+								shortcut_playback_message: {
+									component: 'text',
+									text: 'You may have to manually reset each keybind individually', 
+									style: {
+										marginTop: '10px',  
+										color: '#888',
+										textAlign: 'center'
+									}
 								}
 							}
 						}


### PR DESCRIPTION
The shortcut does not initialize with the key binds saved once the extension is downloaded, so you have to manually click each one and hit 'save' for it to start working. Once saved, they will continue to work indefinitely. I added an informational message within the shortcut's tab to convey that this may be the case for some users. 