### PR TITLE
Add GitHub Actions for closing stale issues and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,38 @@
+## Pull Request Template
+
+### Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+### Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
+
+- [ ] Test A
+- [ ] Test B
+
+### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+### Closing issues
+
+This pull request closes #ISSUE_NUMBER

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,37 +2,38 @@
 
 ### Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+(You can include a summary of the changes and mention the related issue/s Or the relevant context.)  
 
-Fixes # (issue)
+Moreover every contribution is precious and we would like to learn about you:
+Can we return the favor? Are you like to contribute again? Would you like to be invited as member of the organisation? 
 
-### Type of change
+### Fixing Closing issues
 
-Please delete options that are not relevant.
+This pull request closes #ISSUE_NUMBER
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
+### Type of change/s 
+(you can delete options that are not relevant.)
+
+- [ ] Bug fix
+- [ ] New feature 
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
 ### How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
+- [ ] tested
 
-- [ ] Test A
-- [ ] Test B
+In what browser/s? 
 
 ### Checklist:
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
+
+( Doesn't apply to this repo: 
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
+)
 
-### Closing issues
 
-This pull request closes #ISSUE_NUMBER

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: "Close Stale Issues"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          close-issue-message: "This issue has been automatically closed because it has not had recent activity."
+          exempt-issue-labels: "pinned,security"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,23 @@ Welcome to work! ("issues")
 ### https://github.com/code-charity/youtube/wiki/Contributing
 you can also just check the (pinned-)issues(, readme & discussion, wiki, ..)  <br><br>
 ### Thanks for caring ♥
+
+## GitHub Actions Workflow for Closing Stale Issues
+
+We have implemented a GitHub Actions workflow to automatically close stale issues. This helps in keeping the issue tracker clean and focused on active issues.
+
+The workflow is defined in the `.github/workflows/stale.yml` file. It uses the `actions/stale@v4` action to automatically close issues that have been inactive for a specified period. The configuration is as follows:
+
+- `days-before-stale`: 30 days
+- `days-before-close`: 7 days
+- Excludes issues with the `pinned` or `security` labels from being marked as stale
+
+For more details, refer to the [GitHub documentation on closing inactive issues](https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues).
+
+## Pull Request Template
+
+We have added a pull request template to ensure that an issue is closed if a pull request is merged. This helps in keeping the issue tracker up-to-date with the latest changes.
+
+The template is defined in the `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` file. It includes verbiage like "This pull request closes #ISSUE_NUMBER" to ensure that an issue is closed when the pull request is merged.
+
+For more details, refer to the [GitHub documentation on using keywords in issues and pull requests](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).


### PR DESCRIPTION
Fixes #2698

Add a GitHub Actions workflow to close stale issues and a pull request template to ensure issues are closed when pull requests are merged.

* **GitHub Actions Workflow for Closing Stale Issues**
  - Create a new workflow file `.github/workflows/stale.yml`.
  - Use the `actions/stale@v4` action to automatically close issues that have been inactive for 30 days.
  - Set `days-before-stale` to 30 and `days-before-close` to 7.
  - Exclude issues with the `pinned` or `security` labels from being marked as stale.

* **Pull Request Template**
  - Create a new pull request template file `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`.
  - Include verbiage like "This pull request closes #ISSUE_NUMBER" to ensure that an issue is closed when the pull request is merged.

* **Documentation Updates**
  - Update `CONTRIBUTING.md` to include sections about the new GitHub Actions workflow for closing stale issues and the new pull request template.

---

<!--- For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code-charity/youtube/pull/2708?shareId=6a755a42-f983-49fc-b1fa-c4dc77670ef0). --->