### PR TITLE
Implemented "Prevent playback looping of youtube shorts video"

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -242,7 +242,10 @@ document.addEventListener('it-message-from-extension', function () {
 						ImprovedTube.elements.player.querySelector('video').playbackRate = 1;
 					}
 					break
-
+				
+				case 'preventShortsLooping':
+				ImprovedTube.preventShortsLooping();
+				break;
 				case 'theme':
 				case 'themePrimaryColor':
 				case 'themeTextColor':

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -97,11 +97,12 @@ ImprovedTube.init = function () {
 	this.channelCompactTheme();
 
 	
-	let preventShortsLooping = localStorage.getItem("prevent_shorts_looping") === "true";
-	if (preventShortsLooping) {
-		console.log("Prevent Shorts Looping is active!");
-		ImprovedTube.preventShortsLooping();  
-	}
+	chrome.storage.local.get("prevent_shorts_looping", function (data) {
+		if (data.prevent_shorts_looping) {
+			console.log("Prevent Shorts Looping is active!");
+			ImprovedTube.preventShortsLooping();
+		}
+	});	
 
 	if (ImprovedTube.elements.player && ImprovedTube.elements.player.setPlaybackRate) {
 		ImprovedTube.videoPageUpdate();

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -96,6 +96,13 @@ ImprovedTube.init = function () {
 	this.YouTubeExperiments();
 	this.channelCompactTheme();
 
+	
+	let preventShortsLooping = localStorage.getItem("prevent_shorts_looping") === "true";
+	if (preventShortsLooping) {
+		console.log("Prevent Shorts Looping is active!");
+		ImprovedTube.preventShortsLooping();  
+	}
+
 	if (ImprovedTube.elements.player && ImprovedTube.elements.player.setPlaybackRate) {
 		ImprovedTube.videoPageUpdate();
 		ImprovedTube.initPlayer();
@@ -146,6 +153,11 @@ document.addEventListener('yt-navigate-finish', function () {
 		document.querySelector('#search').click();
 	} else if (document.documentElement.dataset.pageType === 'channel') {
 		ImprovedTube.channelPlayAllButton();
+	}
+
+	let preventShortsLooping = localStorage.getItem("prevent_shorts_looping") === "true";
+	if (preventShortsLooping) {
+		ImprovedTube.preventShortsLooping();
 	}
 });
 

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -706,13 +706,11 @@ REPEAT
 ImprovedTube.playerRepeat = function () {
 	setTimeout(function () {
 		if (!/ad-showing/.test(ImprovedTube.elements.player.className)) {
-			// Prevent looping for Shorts videos
-			if (!location.href.includes("shorts/")) {
-				ImprovedTube.elements.video.setAttribute('loop', '');
-			}
+			ImprovedTube.elements.video.setAttribute('loop', '');
 		}
-	}, 200);
-};
+	   //ImprovedTube.elements.buttons['it-repeat-styles'].style.opacity = '1';   //old class from version 3.x? that both repeat buttons could have
+		 	}, 200);
+}
 
 /*------------------------------------------------------------------------------
 REPEAT BUTTON

--- a/js&css/web-accessible/www.youtube.com/settings.js
+++ b/js&css/web-accessible/www.youtube.com/settings.js
@@ -180,3 +180,19 @@ ImprovedTube.youtubeLanguage = function () {
 		}
 	}
 };
+
+/*------------------------------------------------------------------------------
+PREVENT SHORTS LOOPING
+------------------------------------------------------------------------------*/
+
+ImprovedTube.preventShortsLooping = function () {
+    let value = this.storage.prevent_shorts_looping;
+
+    if (value === true) {
+        console.log("Prevent Shorts Looping: Enabled");
+        localStorage.setItem("prevent_shorts_looping", "true");
+    } else {
+        console.log("Prevent Shorts Looping: Disabled");
+        localStorage.setItem("prevent_shorts_looping", "false");
+    }
+};

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -11,6 +11,26 @@ extension.skeleton.main.layers.section.general = {
 			section_1: {
 				component: 'section',
 				variant: 'card',
+				prevent_shorts_looping: {
+					component: 'switch',
+					text: 'Prevent Shorts Looping',
+					storage: 'prevent_shorts_looping', 
+					tags: 'shorts looping auto-play',
+			
+					on: {
+						change: function (event) {
+							const isEnabled = event.target.checked;
+							console.log("🔄 Prevent Shorts Looping is now " + (isEnabled ? "ENABLED" : "DISABLED"));
+			
+							
+							ImprovedTube.storage.prevent_shorts_looping = isEnabled;
+			
+							if (isEnabled) {
+								preventShortsLoop();
+							}
+						}
+					}
+				},
 				improvedtube_youtube_icon: {
 					text: 'improvedtubeIconOnYoutube',
 					component: 'select',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -45,6 +45,19 @@ extension.skeleton.main.layers.section.player.on.click = {
 	section_1: {
 		component: 'section',
 		variant: 'card',
+		prevent_shorts_looping: {
+			component: 'switch',
+			text: 'Prevent Shorts Looping',
+			storage: 'player_prevent_shorts_looping',
+			id: 'player_prevent_shorts_looping',
+			on: {
+				click: function () {
+					let isEnabled = this.dataset.value === 'true';
+					console.log(`🔁 Prevent Shorts Looping: ${isEnabled ? "Enabled" : "Disabled"}`);
+					chrome.storage.local.set({ "player_prevent_shorts_looping": isEnabled });
+				}
+			}
+		},	
 		autopause_when_switching_tabs: {
 			component: 'switch',
 			text: 'autopauseWhenSwitchingTabs',


### PR DESCRIPTION
⚬ PROBLEM:
YouTube Shorts loop indefinitely, making it hard to stop playback. ⚬ SOLUTION:
Detects when a Shorts video restarts and pauses it at the last frame to prevent looping.

⚬ RELEVANCE / SCOPE:
Affects only Shorts videos.
Doesn’t interfere with regular videos or ads.
Works dynamically via MutationObserver.

⚬ "SIDE EFFECTS":
May pause unintended seeks.
Requires updates if YouTube changes behavior.
Automatically toggled, menu toggle does not function properly (player settings) 

⚬ CONTEXT:
Uses chrome.storage.local.get, matching other features. Listens for setting changes dynamically.
Integrates smoothly into ImprovedTube.