### PR TITLE
Hold Ctrl key to rotate video in the opposite direction

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -764,16 +764,21 @@ ImprovedTube.playerRotateButton = function () {
 			id: 'it-rotate-button',
 			child: svg,
 			opacity: 0.85,
-			onclick: function () {
+			onclick: function (e) {
 				var player = ImprovedTube.elements.player,
 					video = ImprovedTube.elements.video,
 					rotate = Number(document.body.dataset.itRotate) || 0,
 					transform = '';
-
-				rotate += 90;
+				if(!e.ctrlKey){
+					rotate += 90;
+				} else {
+					rotate -= 90;
+				}
 
 				if (rotate === 360) {
 					rotate = 0;
+				} else if (rotate < 0){
+					rotate = 270;
 				}
 
 				document.body.dataset.itRotate = rotate;


### PR DESCRIPTION
This commit allows users to rotate the video 90º to the left instead of needing to rotate thrice to the right to achieve the same result.