### PR TITLE
Revert "Resized thumbnails"

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2168,22 +2168,3 @@ html .yt-spec-button-shape-next__icon ytd-lottie-player svg path[fill-opacity="1
 html .yt-spec-button-shape-next__icon ytd-lottie-player svg path[fill-opacity="0"] {
 	stroke: var(--yt-spec-text-primary);
 }
-
-/* Thumbnail Sizes */
-
-html[it-thumbnail-size="x-small"] {
-  --yt-thumb-scale: 0.8;
-}
-html[it-thumbnail-size="small"] {
-  --yt-thumb-scale: 0.9;
-}
-html[it-thumbnail-size="default"] {
-  --yt-thumb-scale: 1;
-}
-
-ytd-rich-item-renderer.style-scope.ytd-rich-grid-renderer,
-ytd-rich-grid-media.style-scope.ytd-rich-item-renderer {
-  transform: scale(var(--yt-thumb-scale));
-  transform-origin: top left;
-  transition: transform 0.2s;
-}

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -259,16 +259,6 @@ extension.skeleton.main.layers.section.general = {
 						value: 'undistracted'
 					}],
 					tags: 'change thumbnails per row'
-				},
-				thumbnail_size: {
-					component: "select",
-					text: "Thumbnail Size",
-					storage: "thumbnail_size",
-					options: [
-						{ text: "Default", value: "default" },
-						{ text: "Small", value: "small" },
-						{ text: "x-small", value: "x-small" }
-					]
 				}
 			}, section_2: {
 				component: 'section',


### PR DESCRIPTION
Reverts code-charity/youtube#2998

while testing I noticed sometimes there might be a small page jump due to the transform. Having fixed sizes causes the feature that allows selecting the number of items per row to not load the correct items per row. Trying to find a approach that allows scaling and doesn't interfere with other features.