### PR TITLE
 Add option to disable spacebar-hold 2x speed playback

### DIFF
--- a/menu/skeleton-parts/shortcuts.js
+++ b/menu/skeleton-parts/shortcuts.js
@@ -180,6 +180,13 @@ extension.skeleton.main.layers.section.shortcuts = {
 						}
 					}
 				},
+				     
+
+				shortcut_disable_spacebar_2x: {
+                     component: 'checkbox',
+                     text: 'Disable spacebar-hold 2x speed',
+                     value: false
+                 },
 				shortcut_stop: {
 					component: 'shortcut',
 					text: 'stop'


### PR DESCRIPTION
When users hold the spacebar (especially by accident) and switch tabs, YouTube interprets it as a 2x playback trigger instead of a pause. This causes unexpected fast playback.

Proposed Solution:
Add a simple toggle in settings:

✔ Disable spacebar-hold for 2x playback

Alternative Options:

Customize or change the keybind for 2x playback.

Justification:

Prevents accidental fast playback.

No risk: This would be an optional toggle.

Increases accessibility and user control.

Side Effects:
None — feature would be opt-in.