### PR TITLE
Fix: prevent misclicks on usernames under comments

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/comments/comments.js
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.js
@@ -15,6 +15,18 @@ extension.features.comments = function (anything) {
 		if (event.type === 'click') {
 			var target = event.target;
 
+			//Prevent misclick
+			let node = target;
+			while (node && node !== document) {
+				if (node.tagName === "A" && node.id === "author-text") {
+					event.preventDefault();
+					event.stopPropagation();
+					// console.log("blocks click on username in comments");
+					return;
+				}
+				node = node.parentNode;
+			}
+
 			if (target.nodeName === 'YTD-COMMENTS-HEADER-RENDERER') {
 				var rect = target.getBoundingClientRect();
 


### PR DESCRIPTION
### Problem
Clicking near a username in comments often directed to the users channel

### Fix
- Intercepts clicks on <a id="author-text"> elements.
- Prevents default navigation & propagation.

### Testing
- Verified in Chrome DevTools.
- Username links are now blocked