### PR TITLE
feat(player): add +/- speed buttons on player bar; cleanup on toggle

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -378,6 +378,8 @@ document.addEventListener('it-message-from-extension', function () {
 				case 'playerPlaybackSpeedButton':
 					if (ImprovedTube.storage.player_playback_speed_button === false) {
 						document.querySelector('#it-playback-speed-button')?.remove();
+						document.querySelector('#it-playback-speed-inc')?.remove();
+						document.querySelector('#it-playback-speed-dec')?.remove();
 					} else if (ImprovedTube.storage.player_playback_speed_button === true) {
 						ImprovedTube.playerPlaybackSpeedButton();
 					}


### PR DESCRIPTION
Hi @procobain , could you please review this PR? Thanks!
Summary
- Added three player controls: [-] [Speed] [+] next to existing controls.
- Uses existing createPlayerButton and playbackSpeed utilities.
- Left-click on [Speed] sets custom speed; right-click resets to 1.0x; wheel adjusts by step.
- Toggle removal cleans up all three: #it-playback-speed-button, #it-playback-speed-inc, #it-playback-speed-dec.
