### PR TITLE
fix: hide duplicate progress bar in miniplayer (#3195)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -38,6 +38,25 @@ html[it-always-show-progress-bar='true'] .html5-video-player:not(.it-mini-player
 }
 
 /*--------------------------------------------------------------
+# FIX: hide full control strip in native miniplayer
+--------------------------------------------------------------*/
+ytd-miniplayer .ytp-chrome-bottom,
+.html5-video-player.ytp-player-minimized .ytp-chrome-bottom,
+.html5-video-player.ytp-small-mode .ytp-chrome-bottom {
+	opacity: 0 !important;
+	pointer-events: none !important;
+}
+
+ytd-miniplayer .ytp-chrome-bottom .ytp-progress-bar-container,
+.html5-video-player.ytp-player-minimized .ytp-chrome-bottom .ytp-progress-bar-container,
+.html5-video-player.ytp-small-mode .ytp-chrome-bottom .ytp-progress-bar-container,
+ytd-miniplayer .ytp-chrome-bottom .ytp-scrubber-button,
+.html5-video-player.ytp-player-minimized .ytp-chrome-bottom .ytp-scrubber-button,
+.html5-video-player.ytp-small-mode .ytp-chrome-bottom .ytp-scrubber-button {
+	display: none !important;
+}
+
+/*--------------------------------------------------------------
 # COLOR
 --------------------------------------------------------------*/
 


### PR DESCRIPTION
### Fixes #3195

**Problem:**
When using ImproveTube with YouTube's native miniplayer, two progress bars were visible:
- The slim native miniplayer bar (at the very bottom), and
- The full player’s `.ytp-chrome-bottom` progress bar forced visible by ImproveTube.

This caused:
- A duplicate bar on hover, and
- The full progress bar overlay blocking clicks on miniplayer controls (pause, expand, close, etc.).

**Cause:**
ImproveTube’s “Always show progress bar” styles only excluded `.it-mini-player`, but YouTube’s current miniplayer uses `.ytp-player-minimized` / `.ytp-small-mode` instead (in some builds also wrapped by `ytd-miniplayer`).

**Solution:**
Added CSS rules to hide the full `.ytp-chrome-bottom` progress UI inside native miniplayer states:

```css
ytd-miniplayer .ytp-chrome-bottom,
.html5-video-player.ytp-player-minimized .ytp-chrome-bottom,
.html5-video-player.ytp-small-mode .ytp-chrome-bottom { ... }
