### PR TITLE
feat(play-all): option to exclude Shorts from "Play All" on channel Videos tab (closes #3188)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1510,5 +1510,8 @@
   },
   "exact": {
     "message": "Exact date/time"
+  },
+  "excludeShortsInPlayAll": {
+    "message": "Exclude Shorts when using \"Play all\""
   }
 }

--- a/menu/skeleton-parts/channel.js
+++ b/menu/skeleton-parts/channel.js
@@ -46,6 +46,11 @@ extension.skeleton.main.layers.section.channel = {
 				component: 'switch',
 				text: 'playAllButton'
 			},
+			exclude_shorts_in_play_all: {
+				component: 'switch',
+				text: 'excludeShortsInPlayAll',
+				value: true
+			  },
 			channel_hide_featured_content: {
 				component: 'switch',
 				text: 'hideFeaturedContent'


### PR DESCRIPTION
What:
- New option: `exclude_shorts_in_play_all` (Channel section).
- When ON: clicking the channel “Play all” button builds a playlist from the visible grid, skipping items that are shorts.
- When OFF: falls back to upload the whole playlist like before.
- Caps list to 50 IDs to avoid long URLs.

Why:
- Requested in #3188: users want long-form-only “Play all”.

How to test:
1) Options → Channel: enable “Play all button” and “Exclude Shorts when using ‘Play all’”.
2) Go to a channel’s "Videos" tab.
3) Click Play all:
   - ON → navigates to a playlist with no shorts.
   - OFF → navigates to playlist with all of channels uploads including videos and shorts if available.
4) Meta-click opens default href (uploads playlist) in new tab.

Notes:
- Scoped only to our injected Play all on the "Videos" tab.
- Does not alter native YouTube playlists.
- i18n: `_locales/en/messages.json` adds `excludeShortsInPlayAll`.
- Storage key is snake_case: `exclude_shorts_in_play_all`.
