### PR TITLE
fix(player): handle mute state explicitly in volume control

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -565,6 +565,16 @@ ImprovedTube.playerVolume = function () {
 		} else {
 			volume = Number(volume);
 		}
+		// Fix: Explicitly handle mute state
+		if (volume === 0) {
+			if (!this.elements.player.isMuted()) {
+				this.elements.player.mute();
+			}
+		} else {
+			if (this.elements.player.isMuted()) {
+				this.elements.player.unMute();
+			}
+		}
 
 		if (!this.audioContextGain && volume <= 100) {
 			if (this.audioContext) {


### PR DESCRIPTION
# fix(player): Correctly handle mute state in forced volume

## Summary
This pull request fixes a bug where setting the player volume to 0% via the "Forced Volume" feature would not mute the audio. The patch ensures that the player's mute state is always synchronized with the volume level, restoring native player behavior.

## Root Cause
The `playerVolume` function directly manipulated the volume level but did not manage the player's separate `isMuted` state. When the volume was set to `0`, the `player.mute()` method was never called, which could leave audio playing.

## Changes
- **`js&css/web-accessible/www.youtube.com/player.js`**: Modified the `playerVolume` function to explicitly call `player.mute()` when the target volume is 0 and `player.unMute()` when it is greater than 0.

## Screenshots

These screenshots demonstrate the fix is working correctly with the "Forced Volume" feature enabled.

### Player Muted at 0% Volume
Shows the player UI correctly displaying a muted state when the volume is set to 0. The audio was confirmed to be silent during testing.

<img width="1872" height="970" alt="image" src="https://github.com/user-attachments/assets/69e654d3-56d3-4d22-bc13-196fd6e0d40d" />

### Player at 100% Volume
Shows the player UI correctly displaying full volume, which was confirmed to be working as expected.

<img width="1873" height="974" alt="image" src="https://github.com/user-attachments/assets/852f12eb-3842-4b89-a5df-5fda9dae09d1" />

## Testing
- Performed manual verification:
    -  Enabled the "Forced Volume" setting.
    -  Lowered the volume to 0% and confirmed the audio became completely silent.
    -  Raised the volume from 0% and confirmed the audio became audible and scaled correctly up to 100%.

## Risk & Rollback
- **Risk**: Low. The change is a targeted bug fix to restore expected behavior and does not affect other features.
- **Rollback**: The commit can be safely reverted using `git revert <commit_hash>`.

## Related
- Closes #3205