### PR TITLE
Fix hide search bar in video page have slight colour different

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/header/header.css
+++ b/js&css/extension/www.youtube.com/appearance/header/header.css
@@ -112,6 +112,7 @@ html[data-page-type='video'][it-header-position=hover_on_video_page]:not([it-imp
 	transform: translateY(-38%);
 	height: 68px;
 	opacity: 0;
+	backdrop-filter: blur(4px);
 }
 
 html[it-header-position=hidden] #masthead-container:not([it-search-focus=true]):focus-within,


### PR DESCRIPTION
Fix a colour bug cause by "backdrop-filter" on the create button at the search bar on chrome browser. 
When the search bar opacity is set to 0 (which is how we hide the search bar), backdrop-filter no longer applied and you should be see a very small color change on the video.

Funny bug as backdrop-filter is on a button but it affected the video too XD