### PR TITLE
Fix: Prevent duplicate player buttons on video navigation -Added uniq…

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -409,8 +409,8 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 		||  this.storage.description == "classic_expanded" || this.storage.description == "classic_hidden"  )
 	   {var section = document.querySelector('#flex.ytd-video-primary-info-renderer');}
    */
-		if (section && !section.querySelector('.improvedtube-player-button')) {
-			if (this.storage.below_player_loop !== false) {
+		if (section) {
+			if (this.storage.below_player_loop !== false && !document.querySelector('#it-below-player-loop')) {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -445,12 +445,13 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				svg.appendChild(path); 	button.appendChild(svg);
 				section.insertAdjacentElement('afterend', button)
 			}
-			if (this.storage.below_player_pip !== false) {
+			if (this.storage.below_player_pip !== false && !document.querySelector('#it-below-player-pip')) {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
 				button.className = 'improvedtube-player-button';
+				button.id = 'it-below-player-pip';
 				button.dataset.tooltip = 'PiP';
 				svg.style.opacity = '.64';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
@@ -464,12 +465,13 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				section.insertAdjacentElement('afterend', button)
 			}
 
-			if (this.storage.below_player_screenshot !== false) {
+			if (this.storage.below_player_screenshot !== false && !document.querySelector('#it-below-player-screenshot')) {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
 				button.className = 'improvedtube-player-button';
+				button.id = 'it-below-player-screenshot';
 				button.dataset.tooltip = 'Screenshot';
 				svg.style.opacity = '.55';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
@@ -481,13 +483,14 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				section.insertAdjacentElement('afterend', button)
 			}
 
-			if (this.storage.below_player_keyscene !== false) {
+			if (this.storage.below_player_keyscene !== false && !document.querySelector('#it-below-player-keyscene')) {
 				var button = document.createElement('button'),
 				svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 				g = document.createElementNS('http://www.w3.org/2000/svg', 'g'),
 				path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
 				button.className = 'improvedtube-player-button';
+				button.id = 'it-below-player-keyscene';
 				button.style.marginRight = '-0.2px';
 				button.dataset.tooltip = 'Key Scene';
 				svg.style.opacity = '.55';
@@ -508,12 +511,13 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 
 			let copyVideoUrlButton = this.storage.copy_video_url === true;
 
-			if (this.storage.copy_video_id === true) {
+			if (this.storage.copy_video_id === true && !document.querySelector('#it-below-player-copy-video-id')) {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
 				button.className = 'improvedtube-player-button';
+				button.id = 'it-below-player-copy-video-id';
 				button.dataset.tooltip = 'CopyVideoId';
 				svg.style.opacity = '.5';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');


### PR DESCRIPTION
 Fixes #3267 - Duplicate player buttons appearing when navigating between videos

  ## Changes Made
  - Added unique IDs to all player buttons (Loop, PiP, Screenshot, Key Scene, Copy Video ID)
  - Changed duplicate check from section-scoped to document-scoped
  - Each button now checks if it already exists globally before creation

  ## Technical Details
  The issue occurred because `section.querySelector('.improvedtube-player-button')` only searched within the section
   element. When YouTube's SPA recreated the section during navigation, the old buttons persisted outside the new
  section, causing duplicates.

  **Solution**: Check for existing buttons at the document level using unique IDs instead of class-based section
  queries.

  ## Testing
  - Tested navigation between multiple videos
  - Verified buttons only appear once
  - Confirmed all button functionality works correctly

  ## Test plan
  - [ ] Navigate between different videos
  - [ ] Verify only one instance of each button appears
  - [ ] Test all button functionality (Loop, PiP, Screenshot, Key Scene, Copy Video ID)