### PR TITLE
Fix/hamburger menu 3295

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1136,6 +1136,7 @@ ImprovedTube.playerHamburgerButton = function () {
 			hamburgerMenu.style.right = '0';
 			hamburgerMenu.style.marginTop = '8px';
 			hamburgerMenu.style.cursor = 'pointer';
+			hamburgerMenu.style.zIndex = 9999;
 
 			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 			svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
@@ -1151,16 +1152,13 @@ ImprovedTube.playerHamburgerButton = function () {
 			controlsContainer.style.paddingRight = '40px';
 			controlsContainer.parentNode.appendChild(hamburgerMenu);
 
-			let controlsVisible = true;
-			controlsContainer.style.display = controlsVisible ? 'none' : 'flex';
-			controlsVisible = false;
+			controlsContainer.style.display = 'none';
+			hamburgerMenu.style.opacity = '0.65';
 
 			hamburgerMenu.addEventListener('click', function () {
-				controlsContainer.style.display = controlsVisible ? 'none' : 'flex';
-				controlsVisible = !controlsVisible;
-
-				// Change the opacity of hamburgerMenu based on controls visibility
-				hamburgerMenu.style.opacity = controlsVisible ? '0.85' : '0.65';
+				const isHidden = controlsContainer.style.display === 'none';
+				controlsContainer.style.display = isHidden ? 'flex' : 'none';
+				hamburgerMenu.style.opacity = isHidden ? '0.85' : '0.65';
 			});
 		}
 	}


### PR DESCRIPTION
refactors the hamburger menu logic in the video player to be more readable. the previous implementation had confusing logic for toggling the visibility of the controls.

So the changes made:
Simplified the click handler logic and
explicitly set the initial state of the controls
added a z-index to the hamburger menu to prevent it from being overlapped by other player elements.

Fixes #3295 

i have already tested it and it works fine.... 👍