### PR TITLE
remove members only videos from recommendations

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -105,6 +105,7 @@ html[it-embeddedHideShare='true'] .ytp-share-button-visible:has(.ytp-share-icon)
 --------------------------------------------------------------*/
 html[it-remove-member-only='true'] ytd-grid-video-renderer:has(.badge-style-type-members-only),
 html[it-remove-member-only='true'] ytd-rich-item-renderer:has(.badge-style-type-members-only),
+html[it-remove-member-only='true'] yt-lockup-view-model:has(.yt-badge-shape--commerce),
 /*--------------------------------------------------------------
 # REMOVE CONTEXT BUTTONS ON SHORTS
 --------------------------------------------------------------*/


### PR DESCRIPTION
YouTube members-only videos have started appearing in up next recommendations. I added a new rule to the existing members-only toggle. This should improve the state of issues like #2874 though I can't confirm whether it's completely gone in all places.