### PR TITLE
Fix dark appearance video delete button

### DIFF
--- a/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
@@ -354,6 +354,8 @@ ImprovedTube.playlistEnsureQuickButtons = function (renderer) {
     svg.style.display = 'inherit';
     svg.style.width = '100%';
     svg.style.height = '100%';
+    svg.style.mixBlendMode = 'difference';
+    svg.style.filter = 'invert(1)';
 
     // Create path for trash icon
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');


### PR DESCRIPTION
This fixes the quick video delete button introduced in https://github.com/code-charity/youtube/pull/3167.

If the dark appearance is enabled, the icon will now appear white. Previously, it was always black.