### PR TITLE
Fix missing closing brace in translation JSON

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1528,6 +1528,7 @@
   },
   "fullScreenQuality": { 
     "message": "Fullscreen quality" 
+  },
   "secondaryColor": {
     "message": "Secondary color"
   },


### PR DESCRIPTION
Added the missing closing brace in the translation JSON file to fix invalid JSON syntax. (Fixes the forgotten brace at [#3238](https://github.com/code-charity/youtube/pull/3238/files#diff-4362c7f7032e9687a0a5910cadc127afbe8259b2b941de40dd4246c35b1446f0R1527))

Additionally, it might be useful to add eslint-plugin-json or a JSON schema check to prevent similar syntax issues in the future.