### PR TITLE
Fix text color on dark backgrounds

### DIFF
--- a/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
@@ -602,6 +602,7 @@ ImprovedTube.playlistCreateBulkControls = function () {
     wrapper.style.flexWrap = 'wrap';
     wrapper.style.zIndex = '2';
     wrapper.style.position = 'relative';
+    wrapper.style.color = 'white';
 
     // Special handling for modern flexible actions layout
     if (vmRow && parent === vmRow) {


### PR DESCRIPTION
This fixes the text color for regular playlists, which are different from the watch later playlist. Previously, the text was dark on a background with a dark gradient.

| Before | After |
|---------|--------|
|  <img width="720" height="222" alt="PixelSnap 2025-11-06 at 10 42 07@2x" src="https://github.com/user-attachments/assets/68dd4aa3-f6b5-41e9-8082-de2b4ed97536" /> | <img width="720" height="214" alt="PixelSnap 2025-11-06 at 10 42 21@2x" src="https://github.com/user-attachments/assets/be2fee70-b07a-40ff-bc25-b503a7c8836b" /> |




