### PR TITLE
fix: cap video quality to 720p when only AI-upscaled 1080p is available

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -464,7 +464,21 @@ ImprovedTube.playerQuality = function (quality = this.storage.player_quality) {
 	if (quality && quality !== 'disabled'
 		&& player && player.getAvailableQualityLevels
 		&& (!player.dataset.defaultQuality || player.dataset.defaultQuality != quality)) {
-		let available_quality_levels = player.getAvailableQualityLevels();
+		try {
+			const available_quality_levels = player.getAvailableQualityLevels?.() || [];
+			const hasTrue1080pOrHigher = available_quality_levels.some(q =>
+				['hd1080', 'hd1440', 'hd2160', 'hd2880', 'highres'].includes(q)
+			);
+			if (
+				!hasTrue1080pOrHigher &&
+				['hd1080', 'hd1440', 'hd2160', 'hd2880', 'highres'].includes(quality)
+			) {
+				console.log('[ImprovedTube] Preventing AI-upscaled "Super Resolution" — capping to 720p.');
+				quality = 'hd720';
+			}
+		} catch (e) {
+			console.warn('[ImprovedTube] Error checking available quality levels', e);
+		}
 		function closest (num, arr) {
 			let curr = arr[0];
 			let diff = Math.abs(num - curr);


### PR DESCRIPTION
This PR fixes the issue where YouTube automatically applies AI-upscaled “Super Resolution” 
to older videos which limited to 720p. 

Changes:
- Updated `ImprovedTube.playerQuality()` in `player.js`
- Checks `getAvailableQualityLevels()` for true 1080p+ options
- Caps automatic selection at 720p if none are available

Fixes #3344 
