### PR TITLE
Dark like button fix

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2150,7 +2150,7 @@ html:not([dark])[it-theme="default"] ytd-watch-flexy[fullscreen] .yt-spec-button
 }
 
 /* Like button splash effect light mode */
-html :not([dark])[it-theme="default"] .yt-spec-button-shape-next__icon ytd-lottie-player svg path[fill-opacity="0"] {
+html:not([dark])[it-theme="default"] .yt-spec-button-shape-next__icon ytd-lottie-player svg path[fill-opacity="0"] {
 	stroke: var(--yt-spec-text-primary-inverse);
 }
 


### PR DESCRIPTION
Related to issue #3298. I fixed the like button color for both light and dark modes. I created four selectors to accurately detect whether YouTube is in dark or light mode based on the page itself (not relying on the extension but on the YouTube settings). Additionally, the solution also handles color changes when the user switches the theme via the extension, ensuring the icons update correctly in all scenarios.

Small note: the commit is marked as `small issue` , it's just me who wrote wrong the commit message ;)