### PR TITLE
Fix: Enable YouTube ad blocker by uncomment hideSponsoredVideosOnHome…

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -727,24 +727,24 @@ extension.features.changeThumbnailsPerRow = async function () {
 # HIDE SPONSORED VIDEOS ON HOME PAGE
 --------------------------------------------------------------*/
 
-// extension.features.hideSponsoredVideosOnHome = function () {
-// 	if (!extension.storage.get('hide_sponsored_videos_home')) return;
-// 	console.log('[ImprovedTube] Hiding sponsored videos on Home');
-// 	const hideSponsored = () => {
-// 		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
-// 			const text = el.innerText || '';
-// 			if (/sponsored/i.test(text)) {
-// 				el.style.display = 'none';
-// 			}
-// 		});
-// 	};
-// 	hideSponsored(); // Initial run
-// 	const observer = new MutationObserver(hideSponsored);
-// 	const pageManager = document.querySelector('ytd-page-manager') || document.body;
-// 	if (pageManager) {
-// 		observer.observe(pageManager, {
-// 			childList: true,
-// 			subtree: true
-// 		});
-// 	}
+extension.features.hideSponsoredVideosOnHome = function () {
+	if (!extension.storage.get('hide_sponsored_videos_home')) return;
+	console.log('[ImprovedTube] Hiding sponsored videos on Home');
+	const hideSponsored = () => {
+		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
+			const text = el.innerText || '';
+			if (/sponsored/i.test(text)) {
+				el.style.display = 'none';
+			}
+		});
+	};
+	hideSponsored(); // Initial run
+	const observer = new MutationObserver(hideSponsored);
+	const pageManager = document.querySelector('ytd-page-manager') || document.body;
+	if (pageManager) {
+		observer.observe(pageManager, {
+			childList: true,
+			subtree: true
+		});
+	}
 // };


### PR DESCRIPTION
… function

This fix addresses issue #3392 where the YouTube ad blocker wasn't working.

The hideSponsoredVideosOnHome function was commented out, preventing ads from being blocked. This commit uncomments the function to restore ad-blocking functionality.

The function hides sponsored video elements on the YouTube home page by:
- Detecting elements with 'sponsored' text
- Setting their display to 'none'
- Using a MutationObserver to handle dynamically loaded content

Fixes #3392