### PR TITLE
Feature: Add option to remove member-only videos from home page

### DIFF
--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -50,6 +50,7 @@ extension.events.on('init', function () {
 	extension.features.comments();
 	extension.features.openNewTab();
 	extension.features.removeListParamOnNewTab();
+	extension.features.removeMemberOnly();
 	// extension.features.hideSponsoredVideosOnHome?.();	
 	bodyReady();
 });

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -748,3 +748,25 @@ extension.features.changeThumbnailsPerRow = async function () {
 // 		});
 // 	}
 // };
+
+/*--------------------------------------------------------------
+# REMOVE MEMBER ONLY VIDEOS FROM HOME PAGE
+--------------------------------------------------------------*/
+extension.features.removeMemberOnly = function () {
+	if (extension.storage.get('remove_member_only')) {
+		const style = document.createElement('style');
+		style.id = 'remove-member-only-style';
+		style.textContent = `
+			badge-shape.yt-badge-shape--membership {
+				display: none !important;
+			}
+			ytd-grid-video-renderer:has(badge-shape.yt-badge-shape--membership),
+			ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership) {
+				display: none !important;
+			}
+		`;
+		document.head.appendChild(style);
+	}
+
+};
+


### PR DESCRIPTION
Related to issue #3386 , i managed to solve this visual bug. Of course, this could be done in other ways, probably by implementing the style into the Css file, but when I tried to do it in this way the problem still occurs when you scroll down and YT loads older video, showing even the 'member only' ones. With mine approach, this doesn't happen.