### PR TITLE
Added Shorts Auto-Scroll

### DIFF
--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -106,6 +106,7 @@ ImprovedTube.init = function () {
 		if (ImprovedTube.storage.prevent_shorts_autoloop) {
 			ImprovedTube.stop_shorts_autoloop();
 		}
+		ImprovedTube.shortsAutoScroll();
 	}
 	if (window.matchMedia) {
 		document.documentElement.dataset.systemColorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -162,6 +163,7 @@ document.addEventListener('yt-navigate-finish', function () {
 		if (ImprovedTube.storage.prevent_shorts_autoloop) {
 			ImprovedTube.stop_shorts_autoloop();
 		}
+		ImprovedTube.shortsAutoScroll();
 	}
 	if (document.documentElement.dataset.pageType === 'home' && ImprovedTube.storage.youtube_home_page === 'search') {
 		document.querySelector('body').style.setProperty('visibility', 'visible', 'important');

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2166,3 +2166,44 @@ ImprovedTube.addYouTubeReturnButton = function () {
         }
     }
 };
+
+/*------------------------------------------------------------------------------
+SHORTS AUTO SCROLL
+------------------------------------------------------------------------------*/
+ImprovedTube.shortsAutoScroll = function () {
+    if (this.storage.shorts_auto_scroll) {
+        if (!ImprovedTube.shortsAutoScrollInterval) {
+            ImprovedTube.shortsAutoScrollInterval = setInterval(() => {
+                if (!location.pathname.startsWith('/shorts/')) return;
+                
+                const activeRenderer = document.querySelector('ytd-reel-video-renderer[is-active]');
+                const video = activeRenderer ? activeRenderer.querySelector('video') : null;
+
+                if (video && !video.dataset.itShortsScrollAttached) {
+                    video.dataset.itShortsScrollAttached = 'true';
+                    
+                    video.addEventListener('timeupdate', function () {
+                        if (!ImprovedTube.storage.shorts_auto_scroll) return;
+                        if (this.paused) return;
+
+                        if (this.duration && this.currentTime >= this.duration - 0.25) {
+                            const nextButton = activeRenderer.querySelector('#navigation-button-down button') 
+                                            || document.querySelector('#navigation-button-down button')
+                                            || document.querySelector('button[aria-label="Next video"]');
+                            
+                            if (nextButton) {
+                                this.pause();
+                                nextButton.click();
+                            }
+                        }
+                    });
+                }
+            }, 1000);
+        }
+    } else {
+        if (ImprovedTube.shortsAutoScrollInterval) {
+            clearInterval(ImprovedTube.shortsAutoScrollInterval);
+            ImprovedTube.shortsAutoScrollInterval = null;
+        }
+    }
+};

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -84,6 +84,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'preventShortVideoAutoloop',
 			storage: 'prevent_shorts_autoloop',
 		},
+		shorts_auto_scroll: {
+			component: 'switch',
+			text: 'autoPlayNextShort',
+			storage: 'shorts_auto_scroll'
+		},
 		autoplay_disable: {
 			component: 'switch',
 			text: 'autoplayDisable',


### PR DESCRIPTION
**Commit Title:** Added "Auto-play next Short" feature (issue:#3380)

**Description:**

* Core Logic (player.js): Implemented ImprovedTube.shortsAutoScroll to detect when a Short is ending (0.25s remaining) and    automatically click the "Next" button, preventing the default looping behavior.

* UI (menu/skeleton-parts/player.js): Added a "shorts_auto_scroll" toggle switch to the Player menu to enable/disable the feature.

* Initialization (init.js): Updated init() and yt-navigate-finish listeners to trigger the auto-scroll observer on page load and navigation.

* **Note:** _Disable Shorts: Force to use the standard player option while using the auto scroll._

* Working Video of Auto Scroll when it is enabled ⬇️

https://github.com/user-attachments/assets/38c6d1fc-8d4f-4aa7-99a2-74527cf1edad