### PR TITLE
Fix: Don't attach main player handlers to preview players

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -352,7 +352,7 @@ ImprovedTube.playerOnPlay = function () {
 		return function () {
 			// Avoid attaching full player handlers to inline/thumbnail preview players
 			// (YouTube uses different preview elements such as `ytd-video-preview`).
-			if (!this.closest('#inline-preview-player') && !this.closest('ytd-video-preview') && !this.closest('.ytd-video-preview') && !this.closest('.ytp-inline-preview')) {
+			if (!this.closest('#inline-preview-player, ytd-video-preview, .ytd-video-preview, .ytp-inline-preview')) {
 				this.removeEventListener('loadedmetadata', ImprovedTube.playerOnLoadedMetadata);
 				this.addEventListener('loadedmetadata', ImprovedTube.playerOnLoadedMetadata);
 


### PR DESCRIPTION
Desc : 
When “play on hover” / thumbnail previews are enabled, preview playback was getting the same event handlers and UI toggles meant for the main player. That caused the preview progress bar to be hidden and — in some cases — opening a video from the preview would trigger unexpected restarts in the main player. This PR keeps preview players isolated so their playback doesn't interfere with the main player.

Changes :
Update the HTMLMediaElement.prototype.play wrapper so it skips attaching main-player handlers when the video element is inside preview elements 