### PR TITLE
Fix crash when YouTube home pagFix crash when YouTube home page runs before DOM is readye runs before DOM is ready

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -19,6 +19,10 @@
 --------------------------------------------------------------*/
 
 extension.features.youtubeHomePage = function (anything) {
+	    // Guard: prevent errors when DOM or event is not ready
+    if (!anything || typeof document === 'undefined' || !document.body) {
+    return;
+}
 	if (anything instanceof Event) {
 		var event = anything;
 


### PR DESCRIPTION
### Summary
Fixes a crash caused when the YouTube home page feature runs before the DOM is ready.

### Changes
- Added guard checks for document and document.body
- Prevents runtime errors on early execution

Fixes #3460
