### PR TITLE
fix #3469: fullscreen quality not reapplied after fullscreen toggle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -730,6 +730,7 @@
   },
   "hideSponsoredVideosOnHome": {
     "message": "Hide sponsored videos on Home page"
+  },
   "hidePauseOverlay": {
     "message": "Hide Pause Overlay"
   },

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -538,7 +538,10 @@ ImprovedTube.playerQualityFullScreen = function () {
      document.mozFullScreen
    );
 
+   var fsq=ImprovedTube.storage.full_screen_quality;
    var target = isFs ? fsq : ImprovedTube.storage.player_quality;
+
+
 
    var map = {
      '144p':'tiny','240p':'small','360p':'medium','480p':'large',
@@ -548,16 +551,25 @@ ImprovedTube.playerQualityFullScreen = function () {
    };
    var desired = map[target] || target;
 
-   var player = ImprovedTube.elements && ImprovedTube.elements.player;
-   if (!player) return;
+   function applyQuality(){
+		 var player = ImprovedTube.elements && ImprovedTube.elements.player;
+   		if (!player) return;
 
-   if (typeof ImprovedTube.playerQuality === 'function') {
-     ImprovedTube.playerQuality(desired);
-     return;
+   		if (typeof ImprovedTube.playerQuality === 'function') {
+     	ImprovedTube.playerQuality(desired);
+
+     	return;
+		
    }
-   try { if (typeof player.setPlaybackQualityRange === 'function') player.setPlaybackQualityRange(desired, desired); } catch(e) {}
-   try { if (typeof player.setPlaybackQuality === 'function') player.setPlaybackQuality(desired); } catch(e) {}
+   try { if (typeof player.setPlaybackQualityRange === 'function') player.setPlaybackQualityRange(desired, desired); } catch(e) {console.log(e)}
+   try { if (typeof player.setPlaybackQuality === 'function') player.setPlaybackQuality(desired); } catch(e) {console.log(e)}
  }
+
+  setTimeout(applyQuality, 300);
+  setTimeout(applyQuality, 800);
+   }
+
+  
 /*------------------------------------------------------------------------------
 BATTERY FEATURES;   PLAYER QUALITY BASED ON POWER STATUS
 ------------------------------------------------------------------------------*/


### PR DESCRIPTION
### Description
The **Fullscreen quality** option does not work as expected.
Only the normal video quality setting is applied, and entering fullscreen does not change the playback quality according to the configured fullscreen preference.

---

### Steps to reproduce
1. Set a value for **Fullscreen quality** in ImprovedTube settings.
2. Play any YouTube video.
3. Enter fullscreen.
4. Observe that the playback quality does not change.

---

### Expected behavior
- The configured **Fullscreen quality** should be applied when entering fullscreen.

---

### Actual behavior
- Playback quality remains unchanged.
- Only the normal video quality setting is respected.

---

### Root cause
Recent changes in the YouTube player override or reset playback quality when fullscreen mode is entered, preventing the extension from applying the configured fullscreen quality.

---

### Changes in this PR
- Apply fullscreen quality when entering fullscreen mode
- Add delayed application to ensure compatibility with asynchronous YouTube player initialization
- Fix an invalid JSON bracket in `_locales/en/messages.json` that prevented the extension from loading correctly

---

### Tested on
- Chrome (latest)
- Firefox (latest)
- Edge (latest)

---

### Test conditions
- Extension enabled as the only active extension
- Logged in and logged out of YouTube
- Manual testing via browser developer mode

---

### ImprovedTube Version
- 4.1400

---
### Notes
- Fixed a missing `},` in `_locales/en/messages.json` that caused the extension to fail loading.

Fixes #3469 