### PR TITLE
Fix: invalid background.background.scripts in manifest3Firefox.json

### DIFF
--- a/build/manifest3Firefox.json
+++ b/build/manifest3Firefox.json
@@ -17,7 +17,6 @@
 		}
 	},
   	"background": {
-    		"background.scripts": "background.js",
     		"scripts": [ "background.js" ]
   	},
 	"action": {


### PR DESCRIPTION
**Title:**

Fix invalid background.background.scripts property in Firefox manifest

**Description:**

Firefox 146+ reports a warning due to an invalid background.background.scripts property in manifestFirefox.json.
This key is not part of the WebExtension specification and is ignored by Chrome but flagged by Firefox.
The fix removes the invalid property while preserving the correct background.scripts entry.


Reference issue: #3482