### PR TITLE
bugfix/wheel-shortcut-player-detection

### DIFF
--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -122,16 +122,24 @@ ImprovedTube.shortcutsListeners = {
 		}
 	},
 	wheel: function (event) {
-		// shortcuts with wheel allowed ONLY inside player
-		if (!ImprovedTube.elements.player?.contains(event.target)) return;
+	const player = ImprovedTube.elements.player;
+	if (!player) return;
 
-		ImprovedTube.input.pressed.wheel = event.deltaY > 0 ? 1 : -1;
-		ImprovedTube.input.pressed.alt = event.altKey;
-		ImprovedTube.input.pressed.ctrl = event.ctrlKey;
-		ImprovedTube.input.pressed.shift = event.shiftKey;
+	const path = event.composedPath?.() || [];
 
-		ImprovedTube.shortcutsHandler();
-	},
+	if (
+		!player.matches(':hover') &&
+		!path.includes(player) &&
+		!path.includes(ImprovedTube.elements.video)
+	) return;
+
+	ImprovedTube.input.pressed.wheel = event.deltaY > 0 ? 1 : -1;
+	ImprovedTube.input.pressed.alt = event.altKey;
+	ImprovedTube.input.pressed.ctrl = event.ctrlKey;
+	ImprovedTube.input.pressed.shift = event.shiftKey;
+
+	ImprovedTube.shortcutsHandler();
+},
 	'improvedtube-blur': function () {
 		ImprovedTube.input.pressed.keys.clear();
 		ImprovedTube.input.pressed.wheel = 0


### PR DESCRIPTION
This PR fixes the issue where the Alt + Mouse Wheel shortcut for changing playback speed stopped working due to recent YouTube DOM changes. Previously, the wheel handler relied on player.contains(event.target), which now fails because wheel events often originate from overlay or shadow DOM elements. This change replaces that strict check with a more reliable approach using the player’s :hover state and event.composedPath() to correctly detect when the cursor is over the video player. As a result, Alt + Scroll Up/Down works again as expected, keyboard shortcuts remain unaffected, and the fix is minimal, targeted, and more resilient to future YouTube UI updates.

<img width="1368" height="874" alt="image" src="https://github.com/user-attachments/assets/16e5f63a-f9c5-418a-9695-b19a97e78b9e" />

this function has improved