### PR TITLE
Import languages sequentially

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1028,19 +1028,23 @@ satus.locale.get = function (string) {
 --------------------------------------------------------------*/
 satus.locale.import = function (code, callback, path) {
 	// if (!path) {  path = '_locales/';   }
+	let promiseChain = Promise.resolve();
+	
 	function importLocale (locale, successCallback) {
-		var url = chrome.runtime.getURL(path + locale + '/messages.json');
-		fetch(url)
-			.then(response => response.ok ? response.json() : {})
-			.then(data => {
-				for (var key in data) {
-					if (!satus.locale.data[key]) {
-						satus.locale.data[key] = data[key].message;
+		promiseChain = promiseChain.then(() => {
+			var url = chrome.runtime.getURL(path + locale + '/messages.json');
+			return fetch(url)
+				.then(response => response.ok ? response.json() : {})
+				.then(data => {
+					for (var key in data) {
+						if (!satus.locale.data[key]) {
+							satus.locale.data[key] = data[key].message;
+						}
 					}
-				}
-			})
-			.catch(() => {})
-			.finally(() => successCallback && successCallback());
+				})
+				.catch(() => {})
+				.finally(() => successCallback && successCallback());
+		});
 	}
 	if (code) {
 		let language = code.replace('-', '_');


### PR DESCRIPTION
Fixes #3125.

Language strings are now selected based on the hierarchy defined in chrome://settings/languages, instead of whatever language loads first.