### PR TITLE
fix: Cinema mode from blocking video

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1089,7 +1089,7 @@ function createOverlay () {
 	overlay.style.backgroundColor = 'rgba(0, 0, 0, 1)';
 	overlay.style.zIndex = '9999';
 	overlay.style.display = 'block';
-	document.body.appendChild(overlay);
+	document.getElementById('full-bleed-container').appendChild(overlay);
 }
 
 ImprovedTube.playerCinemaModeButton = function () {
@@ -1106,18 +1106,13 @@ ImprovedTube.playerCinemaModeButton = function () {
 		this.createPlayerButton({
 			id: 'it-cinema-mode-button',
 			child: svg,
-			// position: "right", // using right only works when we also have fit to window button enabled for some reason
 			opacity: 0.64,
 			onclick: function () {
-				var player = xpath('//*[@id="movie_player"]/div[1]/video')[0].parentNode.parentNode
-				// console.log(player)
-				if (player.style.zIndex == 10000) {
-					player.style.zIndex = 1;
-					svg.parentNode.style.opacity = 0.64;
-					svg.parentNode.style.zIndex = 1;
+				var playerContainer = document.getElementById('player-full-bleed-container');
+				if (playerContainer.style.zIndex == 10000) {
+					playerContainer.style.zIndex = 1;
 				} else {
-					player.style.zIndex = 10000;
-					svg.parentNode.style.opacity = 1;
+					playerContainer.style.zIndex = 10000;
 				}
 
 				var overlay = document.getElementById('overlay_cinema');
@@ -1126,7 +1121,6 @@ ImprovedTube.playerCinemaModeButton = function () {
 				} else {
 					overlay.style.display = overlay.style.display === 'none' || overlay.style.display === '' ? 'block' : 'none';
 				}
-				//console.log(overlay)
 			},
 			title: 'Cinema Mode'
 		});
@@ -1138,8 +1132,8 @@ ImprovedTube.playerCinemaModeDisable = function () {
 		var overlay = document.getElementById('overlay_cinema');
 		if (overlay) {
 			overlay.style.display = 'none'
-			var player = xpath('//*[@id="movie_player"]/div[1]/video')[0].parentNode.parentNode
-			player.style.zIndex = 1;
+			var playerContainer = document.getElementById('player-full-bleed-container');
+			playerContainer.style.zIndex = 1;
 			var cinemaModeButton = xpath('//*[@id="it-cinema-mode-button"]')[0]
 			cinemaModeButton.style.opacity = 0.64
 		}
@@ -1157,12 +1151,11 @@ ImprovedTube.playerCinemaModeEnable = function () {
 				overlay = document.getElementById('overlay_cinema');
 			}
 
-			// console.log(overlay && this.storage.player_auto_hide_cinema_mode_when_paused === true || this.storage.player_auto_cinema_mode === true && overlay)
 			if (overlay) {
 				overlay.style.display = 'block'
-				var player = xpath('//*[@id="movie_player"]/div[1]/video')[0].parentNode.parentNode
+				var player = document.getElementById('player-full-bleed-container');
 				player.style.zIndex = 10000;
-				// console.log(player)
+
 				var cinemaModeButton = xpath('//*[@id="it-cinema-mode-button"]')[0]
 				cinemaModeButton.style.opacity = 1
 			}

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -620,11 +620,11 @@ ImprovedTube.shortcutActivateFitToWindow = function() {
 4.7.31 CINEMA MODE
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutCinemaMode = function () {
-	var player = xpath('//*[@id="movie_player"]/div[1]/video')[0].parentNode.parentNode
-	if (player.style.zIndex == 10000) {
-		player.style.zIndex = 1;
+	var playerContainer = document.getElementById('player-full-bleed-container');
+	if (playerContainer.style.zIndex == 10000) {
+		playerContainer.style.zIndex = 1;
 	} else {
-		player.style.zIndex = 10000;
+		playerContainer.style.zIndex = 10000;
 	}
 	
 	var overlay = document.getElementById('overlay_cinema');


### PR DESCRIPTION
Insert #overlay_cinema in #movie_player stacking context

Manipulate z-index of player-full-bleed-container as player was not showing in cinema mode.

Cinema mode before these changes

<img width="1100" height="896" alt="image" src="https://github.com/user-attachments/assets/5e33f55c-f7e4-4bc2-84ef-b0ccd7970f66" />


Before enabling (after changes)

<img width="1100" height="896" alt="image" src="https://github.com/user-attachments/assets/fec439a0-e703-4a0e-8fc9-b2ccf1b6932d" />

After enabling (after changes)

<img width="1100" height="896" alt="image" src="https://github.com/user-attachments/assets/f22deeee-af13-4e9b-ba02-e5c8bb54d979" />


Fixes #3458
Fixes #3449
Fixes #3031