### PR TITLE
Fix: cinema mode toggle leads to black screen

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1109,11 +1109,23 @@ ImprovedTube.playerCinemaModeButton = function () {
 			opacity: 0.64,
 			onclick: function () {
 				var playerContainer = document.getElementById('player-full-bleed-container');
-				if (playerContainer.style.zIndex == 10000) {
-					playerContainer.style.zIndex = 1;
+				var playerContainerDefault =
+					document.getElementById("player-container");
+				var zIndex = 1;
+
+				if (
+					(playerContainer && playerContainer.style.zIndex == 10000) ||
+					(playerContainerDefault &&
+						playerContainerDefault.style.zIndex == 10000)
+					) {
+					zIndex = 1;
 				} else {
-					playerContainer.style.zIndex = 10000;
+					zIndex = 10000;
 				}
+
+				if (playerContainer) playerContainer.style.zIndex = zIndex;
+				if (playerContainerDefault)
+					playerContainerDefault.style.zIndex = zIndex;
 
 				var overlay = document.getElementById('overlay_cinema');
 				if (!overlay) {
@@ -1133,9 +1145,11 @@ ImprovedTube.playerCinemaModeDisable = function () {
 		if (overlay) {
 			overlay.style.display = 'none'
 			var playerContainer = document.getElementById('player-full-bleed-container');
-			playerContainer.style.zIndex = 1;
+			if (playerContainer) playerContainer.style.zIndex = 1;
+			var playerContainerDefault = document.getElementById('player-container');
+			if (playerContainerDefault) playerContainerDefault.style.zIndex = 1;
 			var cinemaModeButton = xpath('//*[@id="it-cinema-mode-button"]')[0]
-			cinemaModeButton.style.opacity = 0.64
+			if (cinemaModeButton) cinemaModeButton.style.opacity = 0.64
 		}
 	}
 }
@@ -1154,10 +1168,12 @@ ImprovedTube.playerCinemaModeEnable = function () {
 			if (overlay) {
 				overlay.style.display = 'block'
 				var player = document.getElementById('player-full-bleed-container');
-				player.style.zIndex = 10000;
+				if (player) player.style.zIndex = 10000;
+				var playerDefault = document.getElementById('player-container');
+				if (playerDefault) playerDefault.style.zIndex = 10000;
 
 				var cinemaModeButton = xpath('//*[@id="it-cinema-mode-button"]')[0]
-				cinemaModeButton.style.opacity = 1
+				if (cinemaModeButton) cinemaModeButton.style.opacity = 1
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3517

## Issue
The issue was that when the window width is greater than 1000px (likely in Default view rather than Theater mode), the YouTube player is contained within [player-container] instead of [player-full-bleed-container]. The extension's cinema mode was only bringing [player-full-bleed-container] to the front (z-index 10000), leaving [player-container] behind the black overlay (z-index 9999), resulting in a black screen.

## Changes
I have updated [player.js] to target both [player-full-bleed-container] and [player-container] when toggling cinema mode. This ensures that the active player container is always brought above the overlay.


## Files Modified:
[player.js]: Updated ImprovedTube.
playerCinemaModeButton, ImprovedTube.playerCinemaModeDisable, and [ImprovedTube.playerCinemaModeEnable] to handle both player container IDs.

## Screenshot 
<img width="1873" height="893" alt="image" src="https://github.com/user-attachments/assets/9a7f1e5b-5a34-4efc-aece-8ad699578112" />
