### PR TITLE
Fix small ImprovedTube player icons (issue #3530)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -761,6 +761,15 @@ html[it-revert-theater-button-size='true'] .html5-video-player.ytp-big-mode .ytp
 	display: flex;
 	align-items: center;
 }
+
+/*--------------------------------------------------------------
+# FIX: SMALL IMPROVEDTUBE ICONS IN YOUTUBE NEW UI
+--------------------------------------------------------------*/
+
+.ytp-chrome-controls .it-player-button > svg {
+	padding: 0 !important;
+}
+
 /*------------------------------------------------------------------------------
 ALWAYS SHOW CONTROL BUTTONS
 ------------------------------------------------------------------------------*/


### PR DESCRIPTION
Fixes #3530

YouTube’s new UI applies extra padding to SVG icons inside player controls,
causing the ImproveTube player icons to shrink in.

I have normalized the SVG sizing for ImprovedTube player icons so that they
render at the correct size in the new YouTube UI.
