### PR TITLE
fix: correct day of week display offset (#3556)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -629,14 +629,14 @@ ImprovedTube.dayOfWeek = function () {
 			var element = document.querySelector(".ytd-day-of-week");
 			if (!element) {
 				var label = document.createElement("span");
-				label.textContent = days[tempDate.getDay() + 1] + '  ';
+				label.textContent = days[tempDate.getDay()] + '  ';
 				label.className = "ytd-day-of-week";
 				//update please:
 				try { document.querySelector("#info span:nth-child(2)")?.append(label);	} 
 					catch {	try {document.querySelector("#info #info-strings yt-formatted-string")?.append(label);
 					} catch {}
 				}
-			} // else { element.textContent = days[tempDate.getDay() + 1] + ", "; }
+			} // else { element.textContent = days[tempDate.getDay()] + ", "; }
 		}, 4321);
 	}
 };

--- a/tests/unit/day-of-week.test.js
+++ b/tests/unit/day-of-week.test.js
@@ -1,0 +1,44 @@
+/**
+ * Tests for the dayOfWeek feature
+ * Verifies that Date.getDay() maps correctly to the days array
+ */
+
+describe('Day of Week indexing', () => {
+	const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+	test('Sunday (getDay=0) should map to days[0]="Sunday"', () => {
+		// January 19, 2025 is a Sunday
+		const sundayDate = new Date('2025-01-19');
+		expect(sundayDate.getDay()).toBe(0);
+		expect(days[sundayDate.getDay()]).toBe('Sunday');
+	});
+
+	test('Monday (getDay=1) should map to days[1]="Monday"', () => {
+		// January 20, 2025 is a Monday
+		const mondayDate = new Date('2025-01-20');
+		expect(mondayDate.getDay()).toBe(1);
+		expect(days[mondayDate.getDay()]).toBe('Monday');
+	});
+
+	test('Friday (getDay=5) should map to days[5]="Friday"', () => {
+		// January 16, 2026 is a Friday (from issue #3556)
+		const fridayDate = new Date('2026-01-16');
+		expect(fridayDate.getDay()).toBe(5);
+		expect(days[fridayDate.getDay()]).toBe('Friday');
+	});
+
+	test('Saturday (getDay=6) should map to days[6]="Saturday"', () => {
+		// January 17, 2026 is a Saturday
+		const saturdayDate = new Date('2026-01-17');
+		expect(saturdayDate.getDay()).toBe(6);
+		expect(days[saturdayDate.getDay()]).toBe('Saturday');
+	});
+
+	test('All days of week should be accessible without out-of-bounds error', () => {
+		// Verify no day index causes undefined access
+		for (let i = 0; i < 7; i++) {
+			expect(days[i]).toBeDefined();
+			expect(typeof days[i]).toBe('string');
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Removed incorrect `+1` from `getDay()` index in `dayOfWeek` function
- The days array `["Sunday", "Monday", ...]` starts at index 0, and `Date.getDay()` returns 0 for Sunday
- The `+1` caused the day to be offset by one (Friday showed as Saturday, Saturday showed as `undefined`)

## Test plan
- [x] Added unit tests for day-of-week indexing (`tests/unit/day-of-week.test.js`)
- [x] All existing tests pass (`npm test` - 25 tests)
- [x] Verified fix against the example in issue: January 16, 2026 is correctly identified as Friday

Fixes #3556