### PR TITLE
fix: round playback speed readback to fix floating-point display (#3460)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -120,10 +120,10 @@ ImprovedTube.playbackSpeed = function (newSpeed) {
 
 	if (video?.playbackRate) {
 		video.playbackRate = newSpeed;
-		newSpeed = video.playbackRate;
+		newSpeed = Number(video.playbackRate.toFixed(2));
 	} else if (player?.setPlaybackRate && player.getPlaybackRate) {
 		player.setPlaybackRate(newSpeed);
-		newSpeed = player.getPlaybackRate();
+		newSpeed = Number(player.getPlaybackRate().toFixed(2));
 	} else newSpeed = false;
 
 	return newSpeed;


### PR DESCRIPTION
## Summary

Fixes #3460 — Playback Speed indicator shows too many digits (e.g. `"1.1500000000000001x"` instead of `"1.15x"`).

### Root Cause

The `playbackSpeed()` function in `player.js` was returning raw `video.playbackRate` values after setting speed. Due to IEEE 754 floating-point arithmetic (`1.1 + 0.05 = 1.1500000000000001`), the return value had excessive precision.

The **read** path (line 111) already rounds with `Number(x.toFixed(2))`, but the **write-and-readback** path (lines 123, 126) did not. When callers concatenated this raw value with `'x'` (e.g. `showStatus(speed + 'x')`), it produced strings like `"1.1500000000000001x"` that bypassed `showStatus()`'s `typeof number` → `toFixed(2)` guard.

### Fix

Apply the same `Number(x.toFixed(2))` rounding to the readback values at lines 123 and 126 — consistent with the existing pattern at line 111.

**2 lines changed in 1 file.**

### Testing

- Verified that `(1.1500000000000001).toFixed(2)` returns `"1.15"`
- Traced all 9 call sites that use `playbackSpeed()` return value for display
- Confirmed fix works for increase, decrease, wheel scroll, and button click paths
- No change to actual `video.playbackRate` values set on the element

### Browsers

Affects all browsers (IEEE 754 is universal), reported on Firefox.

Made with [Cursor](https://cursor.com)