### PR TITLE
Improve settings search autofocus reliability

### DIFF
--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -15,7 +15,16 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 	searchPosition: 0,
 	on: {
 		render: function () {
-			this.focus();
+			const ensureFocus = () => {
+				this.focus();
+				this.input?.focus();
+			};
+
+			// Re-focus after paint to keep cursor in the search field reliably.
+			ensureFocus();
+			requestAnimationFrame(ensureFocus);
+			setTimeout(ensureFocus, 0);
+
 			if (this.skeleton.search) {
 				this.value = this.skeleton.search;
 				this.dispatchEvent(new CustomEvent('input'));


### PR DESCRIPTION
Fixes #739\n\nWhat this changes:\n- Keep focus on the settings search field when opened from the search icon.\n- Add a small post-render refocus (requestAnimationFrame + setTimeout 0) to handle race conditions where the initial focus is lost.\n\nWhy:\n- Users report needing an extra click before typing after opening search.\n\nScope:\n- Small UI behavior fix in .\n- No storage/schema changes.