### PR TITLE
Add toggleable content warning bypass (fixes #3591)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,10 @@
-{  
-  "hideSuggestedAction": { "message": "Hide Suggested Action 'View products'" },
-  "hideMerchShelf": { "message": "Hide 'Merch Shelf'" },
+{
+  "hideSuggestedAction": {
+    "message": "Hide Suggested Action 'View products'"
+  },
+  "hideMerchShelf": {
+    "message": "Hide 'Merch Shelf'"
+  },
   "about": {
     "message": "About"
   },
@@ -132,6 +136,9 @@
   },
   "autoPictureInPicture": {
     "message": "Auto Picture-In-Picture"
+  },
+  "autoBypassContentWarning": {
+    "message": "Bypass content warnings"
   },
   "autoplay": {
     "message": "Autoplay"

--- a/js&css/extension/bypass-content-warning.js
+++ b/js&css/extension/bypass-content-warning.js
@@ -1,0 +1,44 @@
+// Fixes GitHub issue #3591: Auto-bypass "I understand and wish to proceed" content warnings
+(function () {
+    let enabled = true; // Default to true
+
+    // Load setting
+    chrome.storage.sync.get('auto_bypass_content_warning', (data) => {
+        if (data.auto_bypass_content_warning !== undefined) {
+            enabled = data.auto_bypass_content_warning;
+        }
+        if (enabled) bypassContentWarning();
+    });
+
+    // Listen for changes
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area === 'sync' && changes.auto_bypass_content_warning) {
+            enabled = changes.auto_bypass_content_warning.newValue;
+            if (enabled) bypassContentWarning();
+        }
+    });
+
+    // Only run on YouTube watch pages
+    const isWatchPage = () => location.pathname === '/watch';
+
+    // Add &rco=1 to URL if missing
+    function bypassContentWarning() {
+        if (!enabled) return;
+
+        if (isWatchPage() && !location.search.includes('rco=1')) {
+            const url = new URL(location.href);
+            url.searchParams.set('rco', '1');
+            history.replaceState(history.state, '', url.toString());
+        }
+    }
+
+    // Handle YouTube (SPA) navigation
+    window.addEventListener('yt-navigate-finish', bypassContentWarning);
+
+    // Fallback: Observe DOM changes to detect URL updates
+    new MutationObserver(() => {
+        if (enabled && isWatchPage() && !location.search.includes('rco=1')) {
+            bypassContentWarning();
+        }
+    }).observe(document, { subtree: true, childList: true });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
       "id": "{3c6bf0cc-3ae2-42fb-9993-0d33104fdcaf}"
     }
   },
-	"background": 	{	
+  "background": {
     "service_worker": "background.js"
   },
   "action": {
@@ -51,16 +51,28 @@
         "js&css/extension/www.youtube.com/general/general.js",
         "js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js",
         "js&css/extension/www.youtube.com/appearance/comments/comments.js",
+        "js&css/extension/bypass-content-warning.js",
         "js&css/extension/init.js"
       ],
-      "matches": ["https://www.youtube.com/*"],
+      "matches": [
+        "https://www.youtube.com/*"
+      ],
       "run_at": "document_start"
     }
   ],
-  "host_permissions": ["https://www.youtube.com/*"],
-  "optional_host_permissions": ["https://returnyoutubedislikeapi.com/*"],
-  "optional_permissions": ["downloads"],
-  "permissions": ["contextMenus", "storage"],
+  "host_permissions": [
+    "https://www.youtube.com/*"
+  ],
+  "optional_host_permissions": [
+    "https://returnyoutubedislikeapi.com/*"
+  ],
+  "optional_permissions": [
+    "downloads"
+  ],
+  "permissions": [
+    "contextMenus",
+    "storage"
+  ],
   "web_accessible_resources": [
     {
       "resources": [
@@ -83,7 +95,9 @@
         "js&css/web-accessible/init.js",
         "menu/icons/48.png"
       ],
-      "matches": ["https://www.youtube.com/*"]
+      "matches": [
+        "https://www.youtube.com/*"
+      ]
     }
   ]
 }

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -34,6 +34,7 @@ extension.skeleton.main.layers.section.general = {
 						value: 'below_player'
 					}]
 				},
+
 				/*			improvedTubeSidePanel: {
 					component: 'switch',
 					text: 'improvedTubeSidePanel'
@@ -41,12 +42,12 @@ extension.skeleton.main.layers.section.general = {
 		*/		default_content_country: {
 					component: 'select',
 					text: 'defaultContentCountry',
-					options:[{text:"default", value:"default"}, {text:"Afghanistan", value:"AF"}, {text:"Albania", value:"AL"}, {text:"Algeria", value:"DZ"}, {text:"AmericanSamoa", value:"AS"}, {text:"Andorra", value:"AD"}, {text:"Angola", value:"AO"}, {text:"Anguilla", value:"AI"}, {text:"Antarctica", value:"AQ"}, {text:"AntiguaandBarbuda", value:"AG"}, {text:"Argentina", value:"AR"}, {text:"Armenia", value:"AM"}, {text:"Aruba", value:"AW"}, {text:"Australia", value:"AU"}, {text:"Austria", value:"AT"}, {text:"Azerbaijan", value:"AZ"}, {text:"Bahrain", value:"BH"}, {text:"BailiwickofGuernsey", value:"GG"}, {text:"Bangladesh", value:"BD"}, {text:"Barbados", value:"BB"}, {text:"Belarus", value:"BY"}, {text:"Belgium", value:"BE"}, {text:"Belize", value:"BZ"}, {text:"Benin", value:"BJ"}, {text:"Bermuda", value:"BM"}, {text:"Bhutan", value:"BT"}, {text:"Bolivia", value:"BO"}, {text:"Bonaire", value:"BQ"}, {text:"BosniaandHerzegovina", value:"BA"}, {text:"Botswana", value:"BW"}, {text:"BouvetIsland", value:"BV"}, {text:"Brazil", value:"BR"}, {text:"BritishIndianOceanTerritory", value:"IO"}, {text:"BritishVirginIslands", value:"VG"}, {text:"Brunei", value:"BN"}, {text:"Bulgaria", value:"BG"}, {text:"BurkinaFaso", value:"BF"}, {text:"Burundi", value:"BI"}, {text:"Cambodia", value:"KH"}, {text:"Cameroon", value:"CM"}, {text:"Canada", value:"CA"}, {text:"CapeVerde", value:"CV"}, {text:"CaymanIslands", value:"KY"}, {text:"CentralAfricanRepublic", value:"CF"}, {text:"Chad", value:"TD"}, {text:"Chile", value:"CL"}, {text:"China", value:"CN"}, {text:"ChristmasIsland", value:"CX"}, {text:"Cocos(Keeling)Islands", value:"CC"}, {text:"CollectivityofSaintMartin", value:"MF"}, {text:"Colombia", value:"CO"}, {text:"Comoros", value:"KM"}, {text:"CookIslands", value:"CK"}, {text:"CostaRica", value:"CR"}, {text:"Croatia", value:"HR"}, {text:"Cuba", value:"CU"}, {text:"Curaçao", value:"CW"}, {text:"Cyprus", value:"CY"}, {text:"CzechRepublic", value:"CZ"}, {text:"DemocraticRepublicoftheCongo", value:"CD"}, {text:"Denmark", value:"DK"}, {text:"Djibouti", value:"DJ"}, {text:"Dominica", value:"DM"}, {text:"DominicanRepublic", value:"DO"}, {text:"EastTimor", value:"TL"}, {text:"Ecuador", value:"EC"}, {text:"Egypt", value:"EG"}, {text:"ElSalvador", value:"SV"}, {text:"EquatorialGuinea", value:"GQ"}, {text:"Eritrea", value:"ER"}, {text:"Estonia", value:"EE"}, {text:"Eswatini", value:"SZ"}, {text:"Ethiopia", value:"ET"}, {text:"FalklandIslands", value:"FK"}, {text:"FaroeIslands", value:"FO"}, {text:"FederatedStatesofMicronesia", value:"FM"}, {text:"Fiji", value:"FJ"}, {text:"Finland", value:"FI"}, {text:"France", value:"FR"}, {text:"FrenchGuiana", value:"GF"}, {text:"FrenchPolynesia", value:"PF"}, {text:"FrenchSouthernandAntarcticLands", value:"TF"}, {text:"Gabon", value:"GA"}, {text:"Georgia(country)", value:"GE"}, {text:"Germany", value:"DE"}, {text:"Ghana", value:"GH"}, {text:"Gibraltar", value:"GI"}, {text:"Greece", value:"GR"}, {text:"Greenland", value:"GL"}, {text:"Grenada", value:"GD"}, {text:"Guadeloupe", value:"GP"}, {text:"Guam", value:"GU"}, {text:"Guatemala", value:"GT"}, {text:"Guinea", value:"GN"}, {text:"Guinea-Bissau", value:"GW"}, {text:"Guyana", value:"GY"}, {text:"Haiti", value:"HT"}, {text:"HeardIslandandMcDonaldIslands", value:"HM"}, {text:"HolySee", value:"VA"}, {text:"Honduras", value:"HN"}, {text:"HongKong", value:"HK"}, {text:"Hungary", value:"HU"}, {text:"Iceland", value:"IS"}, {text:"India", value:"IN"}, {text:"Indonesia", value:"ID"}, {text:"Iran", value:"IR"}, {text:"Iraq", value:"IQ"}, {text:"IsleofMan", value:"IM"}, {text:"Israel", value:"IL"}, {text:"Italy", value:"IT"}, {text:"IvoryCoast", value:"CI"}, {text:"Jamaica", value:"JM"}, {text:"Japan", value:"JP"}, {text:"Jersey", value:"JE"}, {text:"Jordan", value:"JO"}, {text:"Kazakhstan", value:"KZ"}, {text:"Kenya", value:"KE"}, {text:"Kiribati", value:"KI"}, {text:"Kuwait", value:"KW"}, {text:"Kyrgyzstan", value:"KG"}, {text:"Laos", value:"LA"}, {text:"Latvia", value:"LV"}, {text:"Lebanon", value:"LB"}, {text:"Lesotho", value:"LS"}, {text:"Liberia", value:"LR"}, {text:"Libya", value:"LY"}, {text:"Liechtenstein", value:"LI"}, {text:"Lithuania", value:"LT"}, {text:"Luxembourg", value:"LU"}, {text:"Macau", value:"MO"}, {text:"Madagascar", value:"MG"}, {text:"Malawi", value:"MW"}, {text:"Malaysia", value:"MY"}, {text:"Maldives", value:"MV"}, {text:"Mali", value:"ML"}, {text:"Malta", value:"MT"}, {text:"MarshallIslands", value:"MH"}, {text:"Martinique", value:"MQ"}, {text:"Mauritania", value:"MR"}, {text:"Mauritius", value:"MU"}, {text:"Mayotte", value:"YT"}, {text:"Mexico", value:"MX"}, {text:"Moldova", value:"MD"}, {text:"Monaco", value:"MC"}, {text:"Mongolia", value:"MN"}, {text:"Montenegro", value:"ME"}, {text:"Montserrat", value:"MS"}, {text:"Morocco", value:"MA"}, {text:"Mozambique", value:"MZ"}, {text:"Myanmar", value:"MM"}, {text:"Namibia", value:"NA"}, {text:"Nauru", value:"NR"}, {text:"Nepal", value:"NP"}, {text:"Netherlands", value:"NL"}, {text:"NewCaledonia", value:"NC"}, {text:"NewZealand", value:"NZ"}, {text:"Nicaragua", value:"NI"}, {text:"Niger", value:"NE"}, {text:"Nigeria", value:"NG"}, {text:"Niue", value:"NU"}, {text:"NorfolkIsland", value:"NF"}, {text:"NorthKorea", value:"KP"}, {text:"NorthMacedonia", value:"MK"}, {text:"NorthernMarianaIslands", value:"MP"}, {text:"Norway", value:"NO"}, {text:"Oman", value:"OM"}, {text:"Pakistan", value:"PK"}, {text:"Palau", value:"PW"}, {text:"Panama", value:"PA"}, {text:"PapuaNewGuinea", value:"PG"}, {text:"Paraguay", value:"PY"}, {text:"Peru", value:"PE"}, {text:"Philippines", value:"PH"}, {text:"PitcairnIslands", value:"PN"}, {text:"Poland", value:"PL"}, {text:"Portugal", value:"PT"}, {text:"PuertoRico", value:"PR"}, {text:"Qatar", value:"QA"}, {text:"RepublicofIreland", value:"IE"}, {text:"RepublicoftheCongo", value:"CG"}, {text:"Romania", value:"RO"}, {text:"Russia", value:"RU"}, {text:"Rwanda", value:"RW"}, {text:"Réunion", value:"RE"}, {text:"SaintBarthélemy", value:"BL"}, {text:"SaintHelena", value:"SH"}, {text:"SaintKittsandNevis", value:"KN"}, {text:"SaintLucia", value:"LC"}, {text:"SaintPierreandMiquelon", value:"PM"}, {text:"SaintVincentandtheGrenadines", value:"VC"}, {text:"Samoa", value:"WS"}, {text:"SanMarino", value:"SM"}, {text:"SaudiArabia", value:"SA"}, {text:"Senegal", value:"SN"}, {text:"Serbia", value:"RS"}, {text:"Seychelles", value:"SC"}, {text:"SierraLeone", value:"SL"}, {text:"Singapore", value:"SG"}, {text:"SintMaarten", value:"SX"}, {text:"Slovakia", value:"SK"}, {text:"Slovenia", value:"SI"}, {text:"SolomonIslands", value:"SB"}, {text:"Somalia", value:"SO"}, {text:"SouthAfrica", value:"ZA"}, {text:"SouthGeorgiaandtheSouthSandwichIslands", value:"GS"}, {text:"SouthKorea", value:"KR"}, {text:"SouthSudan", value:"SS"}, {text:"Spain", value:"ES"}, {text:"SriLanka", value:"LK"}, {text:"StateofPalestine", value:"PS"}, {text:"Sudan", value:"SD"}, {text:"Suriname", value:"SR"}, {text:"Svalbard", value:"SJ"}, {text:"Sweden", value:"SE"}, {text:"Switzerland", value:"CH"}, {text:"Syria", value:"SY"}, {text:"SãoToméandPríncipe", value:"ST"}, {text:"Taiwan", value:"TW"}, {text:"Tajikistan", value:"TJ"}, {text:"Tanzania", value:"TZ"}, {text:"Thailand", value:"TH"}, {text:"TheBahamas", value:"BS"}, {text:"TheGambia", value:"GM"}, {text:"Togo", value:"TG"}, {text:"Tokelau", value:"TK"}, {text:"Tonga", value:"TO"}, {text:"TrinidadandTobago", value:"TT"}, {text:"Tunisia", value:"TN"}, {text:"Turkey", value:"TR"}, {text:"Turkmenistan", value:"TM"}, {text:"TurksandCaicosIslands", value:"TC"}, {text:"Tuvalu", value:"TV"}, {text:"Uganda", value:"UG"}, {text:"Ukraine", value:"UA"}, {text:"UnitedArabEmirates", value:"AE"}, {text:"UnitedKingdom", value:"GB"}, {text:"UnitedStatesVirginIslands", value:"VI"}, {text:"UnitedStates", value:"UM"}, {text:"UnitedStates", value:"US"}, {text:"Uruguay", value:"UY"}, {text:"Uzbekistan", value:"UZ"}, {text:"Vanuatu", value:"VU"}, {text:"Venezuela", value:"VE"}, {text:"Vietnam", value:"VN"}, {text:"WallisandFutuna", value:"WF"}, {text:"WesternSahara", value:"EH"}, {text:"Yemen", value:"YE"}, {text:"Zambia", value:"ZM"}, {text:"Zimbabwe", value:"ZW"}, {text:"ÅlandIslands", value:"AX"}]
+					options: [{ text: "default", value: "default" }, { text: "Afghanistan", value: "AF" }, { text: "Albania", value: "AL" }, { text: "Algeria", value: "DZ" }, { text: "AmericanSamoa", value: "AS" }, { text: "Andorra", value: "AD" }, { text: "Angola", value: "AO" }, { text: "Anguilla", value: "AI" }, { text: "Antarctica", value: "AQ" }, { text: "AntiguaandBarbuda", value: "AG" }, { text: "Argentina", value: "AR" }, { text: "Armenia", value: "AM" }, { text: "Aruba", value: "AW" }, { text: "Australia", value: "AU" }, { text: "Austria", value: "AT" }, { text: "Azerbaijan", value: "AZ" }, { text: "Bahrain", value: "BH" }, { text: "BailiwickofGuernsey", value: "GG" }, { text: "Bangladesh", value: "BD" }, { text: "Barbados", value: "BB" }, { text: "Belarus", value: "BY" }, { text: "Belgium", value: "BE" }, { text: "Belize", value: "BZ" }, { text: "Benin", value: "BJ" }, { text: "Bermuda", value: "BM" }, { text: "Bhutan", value: "BT" }, { text: "Bolivia", value: "BO" }, { text: "Bonaire", value: "BQ" }, { text: "BosniaandHerzegovina", value: "BA" }, { text: "Botswana", value: "BW" }, { text: "BouvetIsland", value: "BV" }, { text: "Brazil", value: "BR" }, { text: "BritishIndianOceanTerritory", value: "IO" }, { text: "BritishVirginIslands", value: "VG" }, { text: "Brunei", value: "BN" }, { text: "Bulgaria", value: "BG" }, { text: "BurkinaFaso", value: "BF" }, { text: "Burundi", value: "BI" }, { text: "Cambodia", value: "KH" }, { text: "Cameroon", value: "CM" }, { text: "Canada", value: "CA" }, { text: "CapeVerde", value: "CV" }, { text: "CaymanIslands", value: "KY" }, { text: "CentralAfricanRepublic", value: "CF" }, { text: "Chad", value: "TD" }, { text: "Chile", value: "CL" }, { text: "China", value: "CN" }, { text: "ChristmasIsland", value: "CX" }, { text: "Cocos(Keeling)Islands", value: "CC" }, { text: "CollectivityofSaintMartin", value: "MF" }, { text: "Colombia", value: "CO" }, { text: "Comoros", value: "KM" }, { text: "CookIslands", value: "CK" }, { text: "CostaRica", value: "CR" }, { text: "Croatia", value: "HR" }, { text: "Cuba", value: "CU" }, { text: "Curaçao", value: "CW" }, { text: "Cyprus", value: "CY" }, { text: "CzechRepublic", value: "CZ" }, { text: "DemocraticRepublicoftheCongo", value: "CD" }, { text: "Denmark", value: "DK" }, { text: "Djibouti", value: "DJ" }, { text: "Dominica", value: "DM" }, { text: "DominicanRepublic", value: "DO" }, { text: "EastTimor", value: "TL" }, { text: "Ecuador", value: "EC" }, { text: "Egypt", value: "EG" }, { text: "ElSalvador", value: "SV" }, { text: "EquatorialGuinea", value: "GQ" }, { text: "Eritrea", value: "ER" }, { text: "Estonia", value: "EE" }, { text: "Eswatini", value: "SZ" }, { text: "Ethiopia", value: "ET" }, { text: "FalklandIslands", value: "FK" }, { text: "FaroeIslands", value: "FO" }, { text: "FederatedStatesofMicronesia", value: "FM" }, { text: "Fiji", value: "FJ" }, { text: "Finland", value: "FI" }, { text: "France", value: "FR" }, { text: "FrenchGuiana", value: "GF" }, { text: "FrenchPolynesia", value: "PF" }, { text: "FrenchSouthernandAntarcticLands", value: "TF" }, { text: "Gabon", value: "GA" }, { text: "Georgia(country)", value: "GE" }, { text: "Germany", value: "DE" }, { text: "Ghana", value: "GH" }, { text: "Gibraltar", value: "GI" }, { text: "Greece", value: "GR" }, { text: "Greenland", value: "GL" }, { text: "Grenada", value: "GD" }, { text: "Guadeloupe", value: "GP" }, { text: "Guam", value: "GU" }, { text: "Guatemala", value: "GT" }, { text: "Guinea", value: "GN" }, { text: "Guinea-Bissau", value: "GW" }, { text: "Guyana", value: "GY" }, { text: "Haiti", value: "HT" }, { text: "HeardIslandandMcDonaldIslands", value: "HM" }, { text: "HolySee", value: "VA" }, { text: "Honduras", value: "HN" }, { text: "HongKong", value: "HK" }, { text: "Hungary", value: "HU" }, { text: "Iceland", value: "IS" }, { text: "India", value: "IN" }, { text: "Indonesia", value: "ID" }, { text: "Iran", value: "IR" }, { text: "Iraq", value: "IQ" }, { text: "IsleofMan", value: "IM" }, { text: "Israel", value: "IL" }, { text: "Italy", value: "IT" }, { text: "IvoryCoast", value: "CI" }, { text: "Jamaica", value: "JM" }, { text: "Japan", value: "JP" }, { text: "Jersey", value: "JE" }, { text: "Jordan", value: "JO" }, { text: "Kazakhstan", value: "KZ" }, { text: "Kenya", value: "KE" }, { text: "Kiribati", value: "KI" }, { text: "Kuwait", value: "KW" }, { text: "Kyrgyzstan", value: "KG" }, { text: "Laos", value: "LA" }, { text: "Latvia", value: "LV" }, { text: "Lebanon", value: "LB" }, { text: "Lesotho", value: "LS" }, { text: "Liberia", value: "LR" }, { text: "Libya", value: "LY" }, { text: "Liechtenstein", value: "LI" }, { text: "Lithuania", value: "LT" }, { text: "Luxembourg", value: "LU" }, { text: "Macau", value: "MO" }, { text: "Madagascar", value: "MG" }, { text: "Malawi", value: "MW" }, { text: "Malaysia", value: "MY" }, { text: "Maldives", value: "MV" }, { text: "Mali", value: "ML" }, { text: "Malta", value: "MT" }, { text: "MarshallIslands", value: "MH" }, { text: "Martinique", value: "MQ" }, { text: "Mauritania", value: "MR" }, { text: "Mauritius", value: "MU" }, { text: "Mayotte", value: "YT" }, { text: "Mexico", value: "MX" }, { text: "Moldova", value: "MD" }, { text: "Monaco", value: "MC" }, { text: "Mongolia", value: "MN" }, { text: "Montenegro", value: "ME" }, { text: "Montserrat", value: "MS" }, { text: "Morocco", value: "MA" }, { text: "Mozambique", value: "MZ" }, { text: "Myanmar", value: "MM" }, { text: "Namibia", value: "NA" }, { text: "Nauru", value: "NR" }, { text: "Nepal", value: "NP" }, { text: "Netherlands", value: "NL" }, { text: "NewCaledonia", value: "NC" }, { text: "NewZealand", value: "NZ" }, { text: "Nicaragua", value: "NI" }, { text: "Niger", value: "NE" }, { text: "Nigeria", value: "NG" }, { text: "Niue", value: "NU" }, { text: "NorfolkIsland", value: "NF" }, { text: "NorthKorea", value: "KP" }, { text: "NorthMacedonia", value: "MK" }, { text: "NorthernMarianaIslands", value: "MP" }, { text: "Norway", value: "NO" }, { text: "Oman", value: "OM" }, { text: "Pakistan", value: "PK" }, { text: "Palau", value: "PW" }, { text: "Panama", value: "PA" }, { text: "PapuaNewGuinea", value: "PG" }, { text: "Paraguay", value: "PY" }, { text: "Peru", value: "PE" }, { text: "Philippines", value: "PH" }, { text: "PitcairnIslands", value: "PN" }, { text: "Poland", value: "PL" }, { text: "Portugal", value: "PT" }, { text: "PuertoRico", value: "PR" }, { text: "Qatar", value: "QA" }, { text: "RepublicofIreland", value: "IE" }, { text: "RepublicoftheCongo", value: "CG" }, { text: "Romania", value: "RO" }, { text: "Russia", value: "RU" }, { text: "Rwanda", value: "RW" }, { text: "Réunion", value: "RE" }, { text: "SaintBarthélemy", value: "BL" }, { text: "SaintHelena", value: "SH" }, { text: "SaintKittsandNevis", value: "KN" }, { text: "SaintLucia", value: "LC" }, { text: "SaintPierreandMiquelon", value: "PM" }, { text: "SaintVincentandtheGrenadines", value: "VC" }, { text: "Samoa", value: "WS" }, { text: "SanMarino", value: "SM" }, { text: "SaudiArabia", value: "SA" }, { text: "Senegal", value: "SN" }, { text: "Serbia", value: "RS" }, { text: "Seychelles", value: "SC" }, { text: "SierraLeone", value: "SL" }, { text: "Singapore", value: "SG" }, { text: "SintMaarten", value: "SX" }, { text: "Slovakia", value: "SK" }, { text: "Slovenia", value: "SI" }, { text: "SolomonIslands", value: "SB" }, { text: "Somalia", value: "SO" }, { text: "SouthAfrica", value: "ZA" }, { text: "SouthGeorgiaandtheSouthSandwichIslands", value: "GS" }, { text: "SouthKorea", value: "KR" }, { text: "SouthSudan", value: "SS" }, { text: "Spain", value: "ES" }, { text: "SriLanka", value: "LK" }, { text: "StateofPalestine", value: "PS" }, { text: "Sudan", value: "SD" }, { text: "Suriname", value: "SR" }, { text: "Svalbard", value: "SJ" }, { text: "Sweden", value: "SE" }, { text: "Switzerland", value: "CH" }, { text: "Syria", value: "SY" }, { text: "SãoToméandPríncipe", value: "ST" }, { text: "Taiwan", value: "TW" }, { text: "Tajikistan", value: "TJ" }, { text: "Tanzania", value: "TZ" }, { text: "Thailand", value: "TH" }, { text: "TheBahamas", value: "BS" }, { text: "TheGambia", value: "GM" }, { text: "Togo", value: "TG" }, { text: "Tokelau", value: "TK" }, { text: "Tonga", value: "TO" }, { text: "TrinidadandTobago", value: "TT" }, { text: "Tunisia", value: "TN" }, { text: "Turkey", value: "TR" }, { text: "Turkmenistan", value: "TM" }, { text: "TurksandCaicosIslands", value: "TC" }, { text: "Tuvalu", value: "TV" }, { text: "Uganda", value: "UG" }, { text: "Ukraine", value: "UA" }, { text: "UnitedArabEmirates", value: "AE" }, { text: "UnitedKingdom", value: "GB" }, { text: "UnitedStatesVirginIslands", value: "VI" }, { text: "UnitedStates", value: "UM" }, { text: "UnitedStates", value: "US" }, { text: "Uruguay", value: "UY" }, { text: "Uzbekistan", value: "UZ" }, { text: "Vanuatu", value: "VU" }, { text: "Venezuela", value: "VE" }, { text: "Vietnam", value: "VN" }, { text: "WallisandFutuna", value: "WF" }, { text: "WesternSahara", value: "EH" }, { text: "Yemen", value: "YE" }, { text: "Zambia", value: "ZM" }, { text: "Zimbabwe", value: "ZW" }, { text: "ÅlandIslands", value: "AX" }]
 				},
 				cursorLighting: {
 					component: 'switch',
 					text: 'cursorLighting',
-				},		
+				},
 				search: {
 					component: 'section',
 					variant: 'card',
@@ -66,7 +67,7 @@ extension.skeleton.main.layers.section.general = {
 				},
 				redirect_shorts_to_watch: {
 					component: 'switch',
-					text:  'ShortsForceTheStandardPlayer',
+					text: 'ShortsForceTheStandardPlayer',
 				},
 				remove_home_page_shorts: {
 					component: 'switch',
@@ -130,9 +131,9 @@ extension.skeleton.main.layers.section.general = {
 					tags: 'trending,subscriptions,history,watch,search,undistracted,zen'
 				},
 				left: {
-				component: 'section',
-				variant: 'card',
-				title: 'Left_Side_Menu',
+					component: 'section',
+					variant: 'card',
+					title: 'Left_Side_Menu',
 					sticky_navigation: {
 						component: "switch",
 						text: 'stickyNavigation',
@@ -244,7 +245,7 @@ extension.skeleton.main.layers.section.general = {
 					component: "switch",
 					text: "hideThumbnailIcon",
 					tags: "preview",
-				  },
+				},
 				hide_thumbnail_dots: {
 					component: 'switch',
 					text: 'hideThumbnailDots',
@@ -283,7 +284,7 @@ extension.skeleton.main.layers.section.general = {
 					}, {
 						text: '4',
 						value: '4'
-					},{
+					}, {
 						text: '3',
 						value: '3'
 					}, {
@@ -298,22 +299,22 @@ extension.skeleton.main.layers.section.general = {
 					}, {
 						text: '8',
 						value: '8'
-					},{
+					}, {
 						text: '9',
 						value: '9'
-					},{
+					}, {
 						text: '10',
 						value: '10'
-					},{
+					}, {
 						text: '11 (experimental)',
 						value: '11'
-					},{
+					}, {
 						text: '12 (experimental)',
 						value: '12'
-					},{
+					}, {
 						text: '2',
 						value: '2'
-					},{
+					}, {
 						text: '1',
 						value: '1'
 					}],
@@ -328,34 +329,34 @@ extension.skeleton.main.layers.section.general = {
 						{ text: "x-small", value: "x-small" }
 					]
 				},
-                show_last_watched_overlay: {
-                    component: 'switch',
-                    text: 'showLastWatchedOverlay',
-                    value: true, // default aktiv
-                    tags: 'history overlay'
-                },
-                last_watched_overlay_position: {
-                    component: 'select',
-                    text: 'lastWatchedOverlayPosition',
-                    storage: 'last_watched_overlay_position',
-                    options: [
-                        { value: 'bottom-right', text: 'bottomRight' },
-                        { value: 'bottom-left',  text: 'bottomLeft'  },
-                        { value: 'top-right',    text: 'topRight'    },
-                        { value: 'top-left',     text: 'topLeft'     }
-                    ],
-                    value: 'bottom-right'
-                },
-                last_watched_format: {
-                    component: 'select',
-                    text: 'lastWatchedFormat',
-                    storage: 'last_watched_format',
-                    options: [
-                        { value: 'relative', text: 'relative' },
-                        { value: 'exact',    text: 'exact'    }
-                    ],
-                    value: 'relative'
-                }
+				show_last_watched_overlay: {
+					component: 'switch',
+					text: 'showLastWatchedOverlay',
+					value: true, // default aktiv
+					tags: 'history overlay'
+				},
+				last_watched_overlay_position: {
+					component: 'select',
+					text: 'lastWatchedOverlayPosition',
+					storage: 'last_watched_overlay_position',
+					options: [
+						{ value: 'bottom-right', text: 'bottomRight' },
+						{ value: 'bottom-left', text: 'bottomLeft' },
+						{ value: 'top-right', text: 'topRight' },
+						{ value: 'top-left', text: 'topLeft' }
+					],
+					value: 'bottom-right'
+				},
+				last_watched_format: {
+					component: 'select',
+					text: 'lastWatchedFormat',
+					storage: 'last_watched_format',
+					options: [
+						{ value: 'relative', text: 'relative' },
+						{ value: 'exact', text: 'exact' }
+					],
+					value: 'relative'
+				}
 			}, section_2: {
 				component: 'section',
 				variant: 'card',
@@ -385,9 +386,9 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideWatchedVideos'
 				},
 				hide_watch_later: {
-                    component: 'switch',
-                    text: 'Hide Watch Later Videos'
-                },
+					component: 'switch',
+					text: 'Hide Watch Later Videos'
+				},
 				delete_watched_videos: {
 					component: 'button',
 					text: 'deleteWatchedVideos',
@@ -539,8 +540,29 @@ extension.skeleton.main.layers.section.general = {
 					text: 'clickableLinksInDescription'
 				},
 				category_refresh_button: {
-    			component: 'switch',
-    			text: 'categoryRefreshButton'
+					component: 'switch',
+					text: 'categoryRefreshButton'
+				},
+				auto_bypass_content_warning: {
+					component: 'switch',
+					text: 'autoBypassContentWarning',
+					on: {
+						render: function () {
+							const component = this;
+							chrome.storage.sync.get('auto_bypass_content_warning', function (data) {
+								let value = data.auto_bypass_content_warning;
+								if (value === undefined) value = true; // Default true
+
+								component.dataset.value = String(value);
+								component.storage.value = value;
+							});
+						},
+						click: function () {
+							setTimeout(() => {
+								chrome.storage.sync.set({ auto_bypass_content_warning: this.storage.value });
+							});
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Problem
Content warning prompts interrupt playlist autoplay, requiring manual clicks on "I understand and wish to proceed".

## Solution
Added a toggleable feature that automatically appends `&rco=1` parameter to bypass content warnings.

## Changes
- Created `src/content-scripts/bypass-content-warning.js`
- Added toggle in General settings (default: enabled)
- Updated manifest.json with content script registration
- Real-time toggle (no page reload needed)

## User Control
Users can disable the feature if they prefer to see content warnings, as requested by issue author.

## Testing
- ✅ Videos with content warnings auto-play
- ✅ Normal videos unaffected
- ✅ Playlist autoplay continues through warned videos
- ✅ Toggle on/off works immediately
- ✅ Setting persists across sessions

Closes #3591
