### PR TITLE
Fix blocklist not working on homepage thumbnails (Issue #3507)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/blocklist.js
+++ b/js&css/web-accessible/www.youtube.com/blocklist.js
@@ -4,85 +4,86 @@
 ImprovedTube.blocklistNode = function (node) {
 	if (!this.storage.blocklist_activate || !node) return;
 
-	const video = node.href?.match(ImprovedTube.regex.video_id)?.[1] || (node.classList?.contains('ytd-video-preview') ? 'video-preview' : null),
-		channel = node.parentNode?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name,
-		blockedElement = this.blocklistElementTypeHelper(node);
+	const video = node.href?.match(ImprovedTube.regex.video_id)?.[1] || (node.classList?.contains('ytd-video-preview') ? 'video-preview' : null);
+	const container = node.closest('ytd-rich-item-renderer, ytd-compact-video-renderer, ytd-video-renderer, ytd-video-preview');
+
+	const channel = container?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name;
+
+	const blockedElement = this.blocklistElementTypeHelper(node);
 
 	if (!video) return; // not interested in nodes without one
 
-	// YT reuses Thumbnail cells dynamically, need to monitor all created Thumbnail links and dynamically apply/remove 'it-blocklisted-*' classes
+	// YT reuses Thumbnail cells dynamically
 	if (!this.elements.observerList.includes(node)) {
 		this.blocklistObserver.observe(node, {
 			attributes: true,
 			attributeFilter: ['href']
 		});
-		// keeping a list to attach only one observer per tracked element
 		this.elements.observerList.push(node);
 	}
 
-	if (!blockedElement) return; // unknown thumbnail cell type, bail out
+	if (!blockedElement) return; // unknown thumbnail cell type
 
+	// Video blocklist
 	if (ImprovedTube.storage.blocklist?.videos[video]) {
-		// blocklisted video
 		blockedElement.classList.add('it-blocklisted-video');
 	} else {
-		// video not blocklisted, show it. classList.remove() directly as there is no speed benefit to .contains() before
 		blockedElement.classList.remove('it-blocklisted-video');
 	}
+
+	// Channel blocklist
 	if (channel) {
 		if (ImprovedTube.storage.blocklist?.channels[channel]) {
-			// blocked channel
 			blockedElement.classList.add('it-blocklisted-channel');
 		} else {
-			// channel not blocked, show it.
 			blockedElement.classList.remove('it-blocklisted-channel');
 		}
 	}
 
-	// skip blocklist button creation if one already exists, in theory this never happens due to check in functions.js
+	// Skip if button already exists
 	if (node.querySelector("button.it-add-to-blocklist")) return;
 
 	const button = this.createIconButton({
 		type: 'blocklist',
 		className: 'it-add-to-blocklist',
 		onclick: function () {
-			if (!this.parentNode.href) return; // no href no action
-			const video = this.parentNode.href?.match(ImprovedTube.regex.video_id)?.[1],
-				channel = this.parentNode.parentNode?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name
-					// video-preview doesnt have Channel info, extract from source thumbnail
-					|| ((video && this.parentNode?.classList.contains('ytd-video-preview')) ? ImprovedTube.elements.observerList.find(a => a.id == 'thumbnail' && a.href?.match(ImprovedTube.regex.video_id)?.[1] === video).parentNode?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name : null),
-				blockedElement = ImprovedTube.blocklistElementTypeHelper(node),
+			if (!this.parentNode?.href) return;
 
-				// Yes, this is horrible. Cant find better way of extracting title :(
-				title = this.parentNode?.__dataHost?.__data?.data?.title?.runs?.[0]?.text
-					|| this.parentNode.__dataHost?.__data?.data?.title?.simpleText
-					|| this.parentNode.__dataHost?.__data?.videoPreviewData?.accessibilityText
-					|| blockedElement?.querySelector('[title]')?.title;
-			let added = false,
-				type = 'video';
+			const video = this.parentNode.href?.match(ImprovedTube.regex.video_id)?.[1];
+			const container = this.closest('ytd-rich-item-renderer, ytd-compact-video-renderer, ytd-video-renderer, ytd-video-preview');
+
+			const fallbackNode = (video && this.closest('ytd-video-preview')) 
+				? ImprovedTube.elements.observerList.find(a => a.href?.match(ImprovedTube.regex.video_id)?.[1] === video)
+				: null;
+
+			const channel = container?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name
+				|| fallbackNode?.closest('ytd-rich-item-renderer, ytd-compact-video-renderer, ytd-video-renderer, ytd-video-preview')?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name;
+
+			const title = this.parentNode?.__dataHost?.__data?.data?.title?.runs?.[0]?.text
+				|| this.parentNode?.__dataHost?.__data?.data?.title?.simpleText
+				|| this.parentNode?.__dataHost?.__data?.videoPreviewData?.accessibilityText
+				|| (blockedElement?.querySelector('[title]')?.title);
 
 			if (!video || !blockedElement || !title) {
 				console.error('blocklist button: need video ID, blockedElement and title');
 				return;
 			}
 
-			// this button can perform three functions in this particular order:
+			let added = false, type = 'video';
+
 			if (channel && blockedElement.classList.contains('it-blocklisted-channel')) {
-				// unblocking whole channel
 				type = 'channel';
 			} else if (blockedElement.classList.contains('it-blocklisted-video')) {
-				// unblocking blocklisted video
+				// unblocking video
 			} else {
-				// block this video
 				added = true;
 			}
 
-			// this message will trigger 'storage-changed' event and eventually blocklistInit() full rescan
 			ImprovedTube.messages.send({
 				action: 'blocklist',
 				added: added,
 				type: type,
-				id: type == 'channel' ? channel : video,
+				id: type === 'channel' ? channel : video,
 				title: title,
 				when: Date.parse(new Date().toDateString()) / 100000
 			});
@@ -98,43 +99,39 @@ ImprovedTube.blocklistChannel = function (node) {
 
 	const id = location.pathname.match(ImprovedTube.regex.channel)?.groups?.name;
 
-	// Prevent duplicate observers when navigating between tabs
 	if (this.blocklistChannelObserver) {
 		this.blocklistChannelObserver.disconnect();
 	}
 
 	let button = node.parentNode?.parentNode?.querySelector("button.it-add-channel-to-blocklist");
 
-	if (!id) return; // not on channel page
+	if (!id) return;
 
-	// skip button.it-add-channel-to-blocklist creation if one already exists, adjust text only
 	if (button) {
 		button.innerText = this.storage.blocklist.channels[id] ? 'Remove from blocklist' : 'Add to blocklist';
 		return;
 	}
 
 	button = document.createElement('button');
-
 	button.className = 'it-add-channel-to-blocklist';
 	button.innerText = this.storage.blocklist.channels[id] ? 'Remove from blocklist' : 'Add to blocklist';
 	button.onclick = function (event) {
 		event.preventDefault();
 		event.stopPropagation();
 
-		const id = location.pathname.match(ImprovedTube.regex.channel)?.groups?.name,
-			title = this.parentNode.__dataHost?.__data?.data?.title
+		const id = location.pathname.match(ImprovedTube.regex.channel)?.groups?.name;
+		const title = this.parentNode?.__dataHost?.__data?.data?.title
 				|| ytInitialData?.metadata?.channelMetadataRenderer?.title
-				|| document.querySelector('yt-dynamic-text-view-model .yt-core-attributed-string')?.innerText,
-			preview = document.querySelector('yt-decorated-avatar-view-model img')?.src
+				|| document.querySelector('yt-dynamic-text-view-model .yt-core-attributed-string')?.innerText;
+		const preview = document.querySelector('yt-decorated-avatar-view-model img')?.src
 				|| document.querySelector('#channel-header-container #avatar img#img')?.src
-				|| this.parentNode.__dataHost?.__data?.data?.avatar?.thumbnails?.[0]?.url;
+				|| this.parentNode?.__dataHost?.__data?.data?.avatar?.thumbnails?.[0]?.url;
 
 		if (!id || !title) {
 			console.error('blocklist click: no channel ID or metadata');
 			return;
 		}
 
-		// this message will trigger 'storage-changed' event and eventually blocklistInit() full rescan
 		ImprovedTube.messages.send({
 			action: 'blocklist',
 			added: !ImprovedTube.storage.blocklist.channels[id],
@@ -146,19 +143,15 @@ ImprovedTube.blocklistChannel = function (node) {
 		});
 	};
 
-	if (node.parentNode && node.parentNode.parentNode) {
+	if (node.parentNode?.parentNode) {
 		node.parentNode.parentNode.appendChild(button);
 		this.elements.blocklist_buttons.push(button);
 
-		// YT tries to remove all foreign nodes from node.parentNode.parentNode some time after 'yt-navigate-finish'
-		// Need to monitor for it and re-appendChild our button, otherwise it gets deleted when switching to
-		// channel subpages /playlists /featured /videos etc.
 		this.blocklistChannelObserver = new MutationObserver(function () {
 			if (!button.isConnected) {
-				if (node.parentNode && node.parentNode.parentNode) {
+				if (node.parentNode?.parentNode) {
 					node.parentNode.parentNode.appendChild(button);
 				} else {
-					// Stop observing if the parent node is gone to prevent loops
 					this.disconnect();
 				}
 			}
@@ -167,24 +160,22 @@ ImprovedTube.blocklistChannel = function (node) {
 	}
 };
 
-ImprovedTube.handleDislikeButton = function() {	
-	// Wait for the dislike button to exist. YouTube may create/remove it dynamically.
+ImprovedTube.handleDislikeButton = function() {
 	const findButton = () => document.querySelector('dislike-button-view-model button');
 
 	const attach = (dislikeButton) => {
 		if (!dislikeButton) return;
 
-		// Also observe aria-pressed changes directly (more robust than relying on click)
 		const observer = new MutationObserver((mutations) => {
 			for (const m of mutations) {
 				if (m.type === 'attributes' && m.attributeName === 'aria-pressed') {
 					const aria = dislikeButton.getAttribute('aria-pressed');
 					const isDisliked = aria === 'true';
-					console.log('ImprovedTube: aria-pressed changed ->', aria);
 					const videoId = location.href.match(ImprovedTube.regex.video_id)?.[1];
 					const title = document.querySelector('h1.style-scope.ytd-watch-metadata yt-formatted-string')?.textContent;
 					if (!videoId || !title) return;
 					if (!this.storage.blocklist_activate || !this.storage.blocklist_dislike_trigger) return;
+
 					ImprovedTube.messages.send({
 						action: 'blocklist',
 						added: isDisliked,
@@ -206,7 +197,6 @@ ImprovedTube.handleDislikeButton = function() {
 		return;
 	}
 
-	// If button not present yet, watch DOM for it (one-time observer)
 	const rootObserver = new MutationObserver((mutations, obs) => {
 		const b = findButton();
 		if (b) {
@@ -218,68 +208,69 @@ ImprovedTube.handleDislikeButton = function() {
 };
 
 ImprovedTube.blocklistInit = function () {
-	if (this.storage.blocklist_activate) {
-		// initialize and (re)scan whole page. Called on load after 'storage-loaded'
-		// and blocklist 'storage-changed' event (adding/removing blocks)
-		if (!this.storage.blocklist || typeof this.storage.blocklist !== 'object') {
-			this.storage.blocklist = {videos: {}, channels: {}};
-		}
-		if (!this.storage.blocklist.videos || typeof this.storage.blocklist.channels !== 'object') {
-			this.storage.blocklist.videos = {};
-		}
-		if (!this.storage.blocklist.channels || typeof this.storage.blocklist.channels !== 'object') {
-			this.storage.blocklist.channels = {};
-		}
-		for (const thumbnail of document.querySelectorAll('a.ytd-thumbnail[href], a.ytd-video-preview')) {
-			this.blocklistNode(thumbnail);
-		}
-		if (document.querySelector('YTD-SUBSCRIBE-BUTTON-RENDERER, YT-SUBSCRIBE-BUTTON-VIEW-MODEL, YTD-BUTTON-RENDERER.ytd-c4-tabbed-header-renderer')) {
-			this.blocklistChannel(document.querySelector('YTD-SUBSCRIBE-BUTTON-RENDERER, YT-SUBSCRIBE-BUTTON-VIEW-MODEL, YTD-BUTTON-RENDERER.ytd-c4-tabbed-header-renderer'));
-		}
-
-		// Initialize dislike button handler for video pages (if user enabled)
-		if (location.pathname === '/watch' && this.storage.blocklist_dislike_trigger) {
-			this.handleDislikeButton();
-		}
-	} else {
-		// Disable and unload Blocklist
-		// remove all 'it-add-to-blocklist' buttons
-		for (const blocked of this.elements.blocklist_buttons) {
-			blocked.remove();
-		}
+	if (!this.storage.blocklist_activate) {
+		// disable blocklist
+		this.elements.blocklist_buttons.forEach(b => b.remove());
 		this.elements.blocklist_buttons = [];
-		// clear observers list
-		if (this.elements.observerList) {
-			this.elements.observerList = [];
-			// release observer
-			ImprovedTube.blocklistObserver.disconnect();
-		}
-		// clear optional Channel button Observer
-		if (typeof ImprovedTube.blocklistChannelObserver === 'object') {
-			ImprovedTube.blocklistChannelObserver.disconnect();
-		}
-		// remove all video/channel blocks from thumbnails on current page
-		for (const blocked of document.querySelectorAll('.it-blocklisted-video')) {
-			blocked.classList.remove('it-blocklisted-video');
-		}
-		for (const blocked of document.querySelectorAll('.it-blocklisted-channel')) {
-			blocked.classList.remove('it-blocklisted-channel');
-		}
+		if (this.elements.observerList) this.elements.observerList = [];
+		if (ImprovedTube.blocklistObserver) ImprovedTube.blocklistObserver.disconnect();
+		if (ImprovedTube.blocklistChannelObserver) ImprovedTube.blocklistChannelObserver.disconnect();
+		document.querySelectorAll('.it-blocklisted-video, .it-blocklisted-channel').forEach(el => el.classList.remove('it-blocklisted-video', 'it-blocklisted-channel'));
+		return;
+	}
+
+	// ensure storage exists
+	this.storage.blocklist = this.storage.blocklist || {videos: {}, channels: {}};
+	this.storage.blocklist.videos = this.storage.blocklist.videos || {};
+	this.storage.blocklist.channels = this.storage.blocklist.channels || {};
+
+	for (const thumbnail of document.querySelectorAll('a.ytd-thumbnail[href], a.ytd-video-preview')) {
+		this.blocklistNode(thumbnail);
+	}
+
+	const channelBtn = document.querySelector('YTD-SUBSCRIBE-BUTTON-RENDERER, YT-SUBSCRIBE-BUTTON-VIEW-MODEL, YTD-BUTTON-RENDERER.ytd-c4-tabbed-header-renderer');
+	if (channelBtn) this.blocklistChannel(channelBtn);
+
+	if (location.pathname === '/watch' && this.storage.blocklist_dislike_trigger) {
+		this.handleDislikeButton();
 	}
 };
 
 ImprovedTube.blocklistObserver = new MutationObserver(function (mutationList) {
 	for (const mutation of mutationList) {
-		const video = mutation.target.href?.match(ImprovedTube.regex.video_id)?.[1],
-			channel = mutation.target.parentNode?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name
-				// video-preview doesnt have Channel info, extract from source thumbnail
-				|| ((video && mutation.target?.classList.contains('ytd-video-preview')) ? ImprovedTube.elements.observerList.find(a => a.id == 'thumbnail' && a.href?.match(ImprovedTube.regex.video_id)?.[1] === video).parentNode?.__dataHost?.__data?.data?.shortBylineText?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url?.match(ImprovedTube.regex.channel)?.groups?.name : null),
-			blockedElement = ImprovedTube.blocklistElementTypeHelper(mutation.target);
+		const blockedElement = ImprovedTube.blocklistElementTypeHelper(mutation.target);
+		if (!blockedElement) return;
 
-		if (!blockedElement) return; // unknown thumbnail cell type, bail out
+		const video = mutation.target.href?.match(ImprovedTube.regex.video_id)?.[1];
+		const channel = (() => {
+    // normal path
+    const parentData = mutation.target.parentNode?.__dataHost?.__data?.data;
+    const runs = parentData?.shortBylineText?.runs;
+    if (runs && runs.length > 0) {
+        const url = runs[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url;
+        const match = url?.match(ImprovedTube.regex.channel);
+        if (match?.groups?.name) return match.groups.name;
+    }
+
+    // fallback for ytd-video-preview
+    if (video && mutation.target?.classList.contains('ytd-video-preview')) {
+        const found = ImprovedTube.elements.observerList.find(a =>
+            a.href?.match(ImprovedTube.regex.video_id)?.[1] === video
+        );
+        if (!found?.parentNode) return null; // prevent error
+
+        const fallbackData = found.parentNode.__dataHost?.__data?.data;
+        const fallbackRuns = fallbackData?.shortBylineText?.runs;
+        const fallbackUrl = fallbackRuns?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url;
+        const fallbackMatch = fallbackUrl?.match(ImprovedTube.regex.channel);
+        return fallbackMatch?.groups?.name || null;
+    }
+
+    return null;
+})();
+
 
 		if (!video) {
-			// no video ID means monitored thumbnail/video-preview node went inactive
 			blockedElement.classList.remove('it-blocklisted-video');
 			blockedElement.classList.remove('it-blocklisted-channel');
 			return;
@@ -290,8 +281,8 @@ ImprovedTube.blocklistObserver = new MutationObserver(function (mutationList) {
 		} else {
 			blockedElement.classList.remove('it-blocklisted-video');
 		}
-		if (!channel) return;
-		if (ImprovedTube.storage.blocklist?.channels[channel]) {
+
+		if (channel && ImprovedTube.storage.blocklist?.channels[channel]) {
 			blockedElement.classList.add('it-blocklisted-channel');
 		} else {
 			blockedElement.classList.remove('it-blocklisted-channel');
@@ -300,39 +291,26 @@ ImprovedTube.blocklistObserver = new MutationObserver(function (mutationList) {
 });
 
 ImprovedTube.blocklistElementTypeHelper = function (node) {
-	switch (node.parentNode.className.replace('style-scope ', '')) {
+	if (!node?.parentNode) return null;
+
+	const cls = node.parentNode.className?.replace('style-scope ', '');
+	switch (cls) {
 		case 'ytd-compact-video-renderer':
-			// list next to player
-			// node.parentNode.__dataHost.$.dismissible;
 		case 'ytd-rich-item-renderer':
-			// short reel
 		case 'ytd-rich-grid-media':
-			// grid reel
 		case 'ytd-rich-grid-slim-media':
-			// short grid reel
 		case 'ytd-playlist-video-renderer':
-			// playlist page
 		case 'ytd-playlist-panel-video-renderer':
-			// playlist next to player
-			// node.parentNode.closest('ytd-playlist-panel-video-renderer')
 		case 'ytd-structured-description-video-lockup-renderer':
-			// list under the player
-			// node.parentNode.closest('ytd-structured-description-video-lockup-renderer')
-			// or even node.parentNode.closest('ytd-compact-infocard-renderer') === node.parentNode.parentNode.parentNode.parentNode
 		case 'ytd-video-renderer':
-			// search results
 		case 'ytd-video-preview':
-			// subscriptions/search thumbnail video-preview
-			return node.parentNode.parentNode.parentNode;
+			return node.parentNode?.parentNode?.parentNode || null;
 
 		case 'ytd-grid-video-renderer':
-			// channel home screen grid
 		case 'ytd-reel-item-renderer':
-			// reel
-			return node.parentNode.parentNode;
+			return node.parentNode?.parentNode || null;
 
 		default:
-			// unknown ones land here
-			break;
+			return null;
 	}
 };


### PR DESCRIPTION
### Problem
The issue was that YouTube updated their homepage's thumbnail layout, which caused the file `blocklist.js` to fail when extracting information from channels. This caused the block button to improperly render and block videos from the homepage.
### Changes/Modifcations
First, I updated the internal logic inside of `blocklistObserver` to properly detect homepage thumbnail elements. I also changed how the channel ID is gotten from the thumbnail. Then, I verified and ensured that the current code is compatible with YouTube's homepage and its other pages.
### Testing
I tested on several pages, including the homepage and subscription page. I also confirmed on my end that the blocklist button hides videos when blocked.