### PR TITLE
fix: cursor/controls linger after seek when 'hide controls when paused' is enabled (#3634)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1440,12 +1440,15 @@ ImprovedTube.playerControls = function () {
 					};
 
 				// After a seek/click interaction, force-hide controls once the
-				// mouse button is released — regardless of progress-bar hover state.
-				player._it_mouseup_handler && player.removeEventListener('mouseup', player._it_mouseup_handler);
-				player._it_mouseup_handler = function () {
-					scheduleHide();
+				// mouse button is released — listen on document because YouTube's
+				// progress bar stops mouseup propagation to the player element.
+				player._it_mouseup_handler && document.removeEventListener('mouseup', player._it_mouseup_handler);
+				player._it_mouseup_handler = function (e) {
+					if (player.contains(e.target) || document.querySelector('.ytp-progress-bar')?.contains(e.target)) {
+						scheduleHide();
+					}
 				};
-				player.addEventListener('mouseup', player._it_mouseup_handler);
+				document.addEventListener('mouseup', player._it_mouseup_handler);
 
 				return function () {
 					player.showControls();
@@ -1463,7 +1466,7 @@ ImprovedTube.playerControls = function () {
 		player.onmouseleave = null;
 		player.onmousemove = null;
 		if (player._it_mouseup_handler) {
-			player.removeEventListener('mouseup', player._it_mouseup_handler);
+			document.removeEventListener('mouseup', player._it_mouseup_handler);
 			player._it_mouseup_handler = null;
 		}
 	}

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1444,8 +1444,13 @@ ImprovedTube.playerControls = function () {
 				// progress bar stops mouseup propagation to the player element.
 				player._it_mouseup_handler && document.removeEventListener('mouseup', player._it_mouseup_handler);
 				player._it_mouseup_handler = function (e) {
-					if (player.contains(e.target) || document.querySelector('.ytp-progress-bar')?.contains(e.target)) {
-						scheduleHide();
+					const progressBar = document.querySelector('.ytp-progress-bar');
+					if (player.contains(e.target) || progressBar?.contains(e.target)) {
+						// User finished seeking — clear any pending timer and hide immediately,
+						// bypassing the progress-bar hover check that would otherwise keep
+						// controls visible while the cursor rests on the scrubber.
+						clearTimeout(thread);
+						player.hideControls();
 					}
 				};
 				document.addEventListener('mouseup', player._it_mouseup_handler);

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1425,6 +1425,12 @@ ImprovedTube.playerControls = function () {
 			player.onmouseleave = player.hideControls;
 			player.onmousemove = (function () {
 				let thread,
+					scheduleHide = function () {
+						clearTimeout(thread);
+						thread = setTimeout(function () {
+							player.hideControls();
+						}, 1000);
+					},
 					onmousestop = function () {
 						if (document.querySelector(".ytp-progress-bar:hover")) {
 							thread = setTimeout(onmousestop, 1000);
@@ -1432,6 +1438,14 @@ ImprovedTube.playerControls = function () {
 							player.hideControls();
 						}
 					};
+
+				// After a seek/click interaction, force-hide controls once the
+				// mouse button is released — regardless of progress-bar hover state.
+				player._it_mouseup_handler && player.removeEventListener('mouseup', player._it_mouseup_handler);
+				player._it_mouseup_handler = function () {
+					scheduleHide();
+				};
+				player.addEventListener('mouseup', player._it_mouseup_handler);
 
 				return function () {
 					player.showControls();
@@ -1448,6 +1462,10 @@ ImprovedTube.playerControls = function () {
 		player.onmouseenter = null;
 		player.onmouseleave = null;
 		player.onmousemove = null;
+		if (player._it_mouseup_handler) {
+			player.removeEventListener('mouseup', player._it_mouseup_handler);
+			player._it_mouseup_handler = null;
+		}
 	}
 };
 /*#  HIDE VIDEO TITLE IN FULLSCREEN	*/ // Easier with CSS only (see player.css)


### PR DESCRIPTION
## Problem

Fixes #3634

When the **"Hide controls when paused"** setting is enabled, after the user interacts with the progress bar (e.g. seeks to a new position), the mouse cursor and control bar take a long time to disappear — or never disappear until the mouse is moved away.

### Root cause

In `playerControls()`, the `onmousestop` callback checks `.ytp-progress-bar:hover` before hiding controls. After a seek click, the progress bar remains in a `:hover` state, so `onmousestop` keeps rescheduling itself in a 1-second loop indefinitely — the controls never hide.

## Fix

Attach a `mouseup` listener on the player element. When the user releases the mouse button after a seek, it schedules a clean 1-second hide timer that bypasses the hover guard. The listener is properly cleaned up when the feature is disabled or the video resumes playing.

```js
// After a seek/click interaction, force-hide controls once the
// mouse button is released — regardless of progress-bar hover state.
player._it_mouseup_handler = function () {
    scheduleHide(); // clears existing timer, hides after 1s
};
player.addEventListener('mouseup', player._it_mouseup_handler);
```

## Testing

1. Enable **Settings → Player → Hide controls when paused**
2. Pause a video
3. Click the progress bar to seek
4. Keep the mouse still over the progress bar
5. ✅ Controls and cursor now disappear after ~1 second
6. Previously: controls would stay visible indefinitely