### PR TITLE
Fix disableAutoDubbing function to use getLanguageInfo for track names

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2073,8 +2073,8 @@ ImprovedTube.playerIncreaseDecreaseSpeedButtons = function () {
 ------------------------------------------------------------------------------*/
 ImprovedTube.disableAutoDubbing = function () {
 	const player = this.elements.player;
-	const tracks = player.getAvailableAudioTracks();
-	const originalTrack = findOriginalAudioTrack(tracks);
+	const tracks = player?.getAvailableAudioTracks();
+	const originalTrack = tracks ? findOriginalAudioTrack(tracks) : null;
 	
 	if (originalTrack) {
 		player.setAudioTrack(originalTrack);
@@ -2100,18 +2100,14 @@ ImprovedTube.disableAutoDubbing = function () {
 		}
 
 		function hasOriginalKeyword(track) {
-			var name = track?.HB?.name?.toLowerCase() || '';
+			var name = track?.getLanguageInfo?.()?.name?.toLowerCase() || '';
 			const localizedOriginalWords = ['original', 'originale', 'originalny', 'originalaudio', 'origineel', 'orijinal']; // Add more if needed
-			if (name === '') {
-				// Try to get the localized name from other variable
-				name = track?.Af.name?.toLowerCase() || '';
-			}
 			
 			return localizedOriginalWords.some(word => name.includes(word));
 		}
 
 		// As a fallback: default or first item
-		const fallback = audioTracks.find(t => t?.HB?.isDefault) || audioTracks[0];
+		const fallback = audioTracks.find(t => t?.getLanguageInfo?.()?.isDefault) || audioTracks[0];
 		console.log(fallback);
 		return fallback;
 	}


### PR DESCRIPTION
# "Disable autodubbing" feature

## Problem

Fixes https://github.com/code-charity/youtube/issues/3323 & https://github.com/code-charity/youtube/issues/3559

The feature simply does not work anymore. The following error message has been logged : ``` Uncaught TypeError: can't access property "name", track.Af is undefined ```

## Root cause

The current code uses the property name ```HB``` or ```Af``` to get the audio track language info. This property name might be subject to change. Actually, it currently is ```qf``` for me as of this PR which causes the same error as the two above-mentioned issues.

## Fix

Instead of using a property name which could change anytime, we should instead use the available ```getLanguageInfo()``` function which returns the same object as the previous ```HB```, ```Af```, or ```qf```.

## Testing

- Watch a video with autodubs enabled by the creator.
- Make sure that an autodubbed track is selected in the video options.
- Run the ```ImprovedTube.disableAutoDubbing()``` function in the developer console.

&rarr; The audio should switch to the original audio.