### PR TITLE
fix: Safari export settings fails due to unsupported downloads permission

### DIFF
--- a/menu/functions.js
+++ b/menu/functions.js
@@ -73,22 +73,41 @@ extension.exportSettings = function () {
 								var blob = new Blob([JSON.stringify(satus.storage.data)], {
 									type: 'application/json;charset=utf-8'
 								});
+								var url = URL.createObjectURL(blob);
 
-								chrome.permissions.request({
-									permissions: ['downloads']
-								}, function (granted) {
-									if (granted) {
-										chrome.downloads.download({
-											url: URL.createObjectURL(blob),
-											filename: 'improvedtube.json',
-											saveAs: true
-										}, function () {
-											setTimeout(function () {
-												close();
-											}, 1000);
-										});
-									}
-								});
+								// Safari doesn't support the downloads permission, use fallback
+								var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+								
+								if (isSafari) {
+									// Safari fallback: create anchor element to trigger download
+									var a = document.createElement('a');
+									a.href = url;
+									a.download = 'improvedtube.json';
+									document.body.appendChild(a);
+									a.click();
+									document.body.removeChild(a);
+									setTimeout(function () {
+										URL.revokeObjectURL(url);
+										close();
+									}, 1000);
+								} else {
+									// Chrome and other browsers: use downloads API
+									chrome.permissions.request({
+										permissions: ['downloads']
+									}, function (granted) {
+										if (granted) {
+											chrome.downloads.download({
+												url: url,
+												filename: 'improvedtube.json',
+												saveAs: true
+											}, function () {
+												setTimeout(function () {
+													close();
+												}, 1000);
+											});
+										}
+									});
+								}
 							} catch (error) {
 								console.error(error);
 							}


### PR DESCRIPTION
## Problem
Export settings feature was broken in Safari because Safari doesn't support the `chrome.downloads` API and the `downloads` permission.

## Error (from Safari console)
```
Error: Invalid permission (downloads) passed to permissions.request().
```

## Solution
Added Safari detection and a fallback download method:
- Detect Safari via user agent string matching
- For Safari: Create an anchor element with download attribute to trigger file download
- For Chrome/other browsers: Continue using chrome.downloads API

## Changes
- Modified `menu/functions.js` - `extension.exportSettings()` function
- Added Safari-specific fallback using anchor element download
- Properly revoke object URLs to prevent memory leaks

## Testing
- [x] Code follows project style
- [x] Fix handles edge cases (non-Safari browsers still work)

Fixes #1829

/claim