### PR TITLE
fix: disable thumbnail hover playback on sidebar related videos

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -542,8 +542,9 @@ extension.features.thumbnailsQuality = function (anything) {
 --------------------------------------------------------------*/
 extension.features.disableThumbnailPlayback = function (event) {
 	if (event instanceof Event) {
-		if (event.composedPath().some(elem => (elem.matches != null && elem.matches('#content.ytd-rich-item-renderer, #contents.ytd-item-section-renderer'))
-		)) {
+		if (event.composedPath().some(elem => (elem.matches != null && elem.matches(
+			'#content.ytd-rich-item-renderer, #contents.ytd-item-section-renderer, #dismissible.ytd-compact-video-renderer'
+		)))) {
 			event.stopImmediatePropagation();
 		}
 	} else {

--- a/tests/unit/disable-thumbnail-playback.test.js
+++ b/tests/unit/disable-thumbnail-playback.test.js
@@ -1,0 +1,29 @@
+// Test for Issue #3639: Disable video playback on hover not working on sidebar
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Disable Thumbnail Playback (#3639)', () => {
+	let generalContent;
+
+	beforeAll(() => {
+		const filePath = path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.js');
+		generalContent = fs.readFileSync(filePath, 'utf8');
+	});
+
+	test('should match home page grid items', () => {
+		expect(generalContent).toContain('#content.ytd-rich-item-renderer');
+	});
+
+	test('should match search results items', () => {
+		expect(generalContent).toContain('#contents.ytd-item-section-renderer');
+	});
+
+	test('should match sidebar compact video items', () => {
+		expect(generalContent).toContain('#dismissible.ytd-compact-video-renderer');
+	});
+
+	test('should use stopImmediatePropagation to block hover playback', () => {
+		expect(generalContent).toContain('event.stopImmediatePropagation()');
+	});
+});


### PR DESCRIPTION
Fixes #3639

## Problem
"Disable video playback when hovering on thumbnails" only works on the home page and search results. Sidebar related videos use `ytd-compact-video-renderer` which wasn't matched by the event filter.

## Fix
Add `#dismissible.ytd-compact-video-renderer` to the `composedPath` selector in `disableThumbnailPlayback()`.

## Test
- Added `tests/unit/disable-thumbnail-playback.test.js`
- All existing tests pass