### PR TITLE
Fix Next/Previous Video shortcuts breaking out of playlists

### DIFF
--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -249,13 +249,38 @@ ImprovedTube.shortcutToggleAutoplay = function () {
 4.7.7 NEXT VIDEO
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutNextVideo = function () {
-	this.elements.player?.nextVideo();
+	var player = this.elements.player;
+	if (!player) return;
+
+	// In playlist context, use the player's built-in next button which
+	// correctly navigates within the playlist. player.nextVideo() may
+	// navigate outside the playlist on recent YouTube versions.
+	if (ImprovedTube.getParam(location.href, 'list')) {
+		var nextBtn = player.querySelector('.ytp-next-button');
+		if (nextBtn) {
+			nextBtn.click();
+			return;
+		}
+	}
+	player.nextVideo();
 };
 /*------------------------------------------------------------------------------
 4.7.8 PREVIOUS VIDEO
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutPrevVideo = function () {
-	this.elements.player?.previousVideo();
+	var player = this.elements.player;
+	if (!player) return;
+
+	// In playlist context, use the player's built-in prev button which
+	// correctly navigates within the playlist.
+	if (ImprovedTube.getParam(location.href, 'list')) {
+		var prevBtn = player.querySelector('.ytp-prev-button');
+		if (prevBtn) {
+			prevBtn.click();
+			return;
+		}
+	}
+	player.previousVideo();
 };
 /*------------------------------------------------------------------------------
 4.7.9 SEEK BACKWARD


### PR DESCRIPTION
## Summary

- **Fixes #3678** — Next Video shortcut navigates outside playlist instead of to the next video within it
- `shortcutNextVideo` and `shortcutPrevVideo` now detect playlist context (via `list` URL param) and click the player's built-in `.ytp-next-button` / `.ytp-prev-button` instead of calling `player.nextVideo()` / `player.previousVideo()`, which on recent YouTube versions no longer respect playlist context
- Falls back to the original API calls when not in a playlist or if the buttons aren't found

## Changes

**`js&css/web-accessible/www.youtube.com/shortcuts.js`**
- `shortcutNextVideo`: check for playlist, click `.ytp-next-button` if present, else `player.nextVideo()`
- `shortcutPrevVideo`: check for playlist, click `.ytp-prev-button` if present, else `player.previousVideo()`

## Test plan

- [ ] Open a YouTube playlist and press the Next Video shortcut — should advance to next video **within** the playlist
- [ ] Press Previous Video shortcut — should go to previous video within the playlist
- [ ] On a non-playlist video, Next/Previous shortcuts should work as before
- [ ] Verify shortcuts still work when playlist panel is collapsed