### PR TITLE
Add list layout option for Subscriptions page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1238,6 +1238,9 @@
   "removeSubscriptionsMostRelevant": {
     "message": "Hide 'Most relevant' section on Subscriptions page"
   },
+  "subscriptionsListLayout": {
+    "message": "List layout on Subscriptions page"
+  },
   "RemoveSubtitlesForLyrics": {
     "message": "Remove subtitles for lyrics"
   },

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2296,3 +2296,50 @@ html[it-thumbnail-size="x-small"] ytd-compact-video-renderer ytd-thumbnail {
 html[it-thumbnail-size="xx-small"] ytd-compact-video-renderer ytd-thumbnail {
     width: 70px !important;
 }
+
+/*--------------------------------------------------------------
+# SUBSCRIPTIONS LIST LAYOUT
+--------------------------------------------------------------*/
+/* Single-column grid */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-grid-renderer > #contents {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 12px !important;
+}
+
+/* Flatten row wrappers */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-grid-row {
+    display: contents !important;
+}
+
+/* Each video item: horizontal row */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+}
+
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media {
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 16px !important;
+}
+
+/* Thumbnail fixed width on left */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media ytd-thumbnail {
+    min-width: 360px !important;
+    max-width: 360px !important;
+    flex-shrink: 0 !important;
+}
+
+/* Details fill remaining space on right */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media #details {
+    flex: 1 !important;
+    min-width: 0 !important;
+    padding-top: 4px !important;
+}
+
+/* Hide empty items */
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer[is-empty] {
+    display: none !important;
+}

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -101,6 +101,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'removeSubscriptionsMostRelevant',
 					id: 'remove-subscriptions-most-relevant'
 				},
+				subscriptions_list_layout: {
+					component: 'switch',
+					text: 'subscriptionsListLayout',
+					id: 'subscriptions-list-layout'
+				},
 				youtube_home_page: {
 					component: 'select',
 					text: 'youtubeHomePage',


### PR DESCRIPTION
## Add list layout option for Subscriptions page

This PR adds an optional list layout for the YouTube Subscriptions feed.

### Feature

When enabled, the subscriptions page switches from the default grid layout to a vertical list layout where:

* thumbnails appear on the left
* title, channel, and metadata appear on the right

### Implementation

The implementation follows the existing ImprovedTube architecture using a settings toggle that activates CSS rules.

Changes:

* `general.js` – adds the `subscriptions_list_layout` toggle
* `messages.json` – adds translation for "List layout on Subscriptions page"
* `styles.css` – converts the subscriptions grid into a single-column list layout

Key CSS behavior:

* activates only on `/feed/subscriptions`
* flattens `ytd-rich-grid-row` using `display: contents`
* converts the grid into a vertical flex layout
* hides placeholder items
* sets thumbnails to a fixed width and aligns metadata to the right

### Testing

1. Load the extension via `chrome://extensions` → **Load unpacked**
2. Open `https://www.youtube.com/feed/subscriptions`
3. Enable **"List layout on Subscriptions page"** in ImprovedTube settings

The feed should switch from grid tiles to a horizontal list layout.

### Notes

There is currently one unrelated failing test (`test-large-playlist-fix.js`) that references `window.location` in the Node test environment. This appears to be a pre-existing issue and is unrelated to this change.

Closes #3706