### PR TITLE
feat(sidebar): add toggle to disable sidebar independent scroll

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -413,6 +413,9 @@
   "description": {
     "message": "Description"
   },
+  "disableSidebarScroll": {
+    "message": "Disable sidebar scroll"
+  },
   "description_ext": {
     "message": "YouTube, tidy & smart? Supercharge YouTube! Give it strong features, filter only the videos you want & exactly the look you like"
   },

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -288,6 +288,17 @@ html[data-page-type=video][it-no-page-margin='true'] ytd-browse > ytd-two-column
 }
 
 /*--------------------------------------------------------------
+# DISABLE SIDEBAR SCROLL
+--------------------------------------------------------------*/
+html[data-page-type=video][it-disable-sidebar-scroll='true']:not([it-comments-sidebar='true']) #secondary,
+html[data-page-type=video][it-disable-sidebar-scroll='true']:not([it-comments-sidebar='true']) #secondary-inner {
+	position: static !important;
+	overflow-y: visible !important;
+	max-height: none !important;
+	height: auto !important;
+}
+
+/*--------------------------------------------------------------
 # MOVE SIDEBAR LEFT
 --------------------------------------------------------------*/
 html[data-page-type=video][it-sidebar-left='true'] #columns>#primary,

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -1124,6 +1124,10 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 				component: "switch",
 				text: 'hidePlaylist'
 			},
+			disable_sidebar_scroll: {
+				component: "switch",
+				text: "disableSidebarScroll"
+			},
 			hide_sidebar: {
 				component: "switch",
 				text: 'Hide_sidebar'


### PR DESCRIPTION
## Problem

YouTube recently changed its watch page layout so that the Up Next video list (#secondary sidebar) has its own independent scrollbar. Instead of the whole page scrolling as one unit, the sidebar now scrolls separately, which many users find disruptive.

Fixes #3716

## Reproduction

1. Open any YouTube video page
2. Notice the Up Next sidebar on the right has its own scrollbar
3. When scrolling the main page, the sidebar stays fixed and scrolls independently

## Fix Scope

Added a new toggle "Disable sidebar scroll" under Appearance → Sidebar settings. When enabled, it overrides YouTube's sticky positioning and independent scroll on `#secondary` and `#secondary-inner` via CSS (`position: static`, `overflow-y: visible`, `max-height: none`), restoring the unified page scroll behavior.

Files changed:
- `sidebar.css`: CSS override rules (scoped to `[data-page-type=video]`)
- `appearance.js` (menu): New switch component
- `messages.json`: i18n label

## Test Evidence

Chrome Extension CSS feature — manual testing required:
1. Load the modified extension in Chrome
2. Go to extension settings → Appearance → Sidebar
3. Enable "Disable sidebar scroll"
4. Open a YouTube video page
5. Verify the sidebar scrolls with the page as one unit (no independent scrollbar)

## Known Limitations

- Only English i18n string added; other locales will fall back to the key name
- If YouTube changes the DOM structure of `#secondary` / `#secondary-inner`, the CSS selectors may need updating
- The fix targets the standard watch page layout; theater mode and fullscreen are unaffected
- When "Comments sidebar" is enabled, this toggle is intentionally inactive to avoid layout conflicts