### PR TITLE
Fix custom mini player covered by page content (z-index)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -17,7 +17,7 @@ html[it-ambient-lighting='false'] #cinematics {display: none !important;}
 /*--------------------------------------------------------------
 # MINI PLAYER Z-INDEX FIX
 --------------------------------------------------------------*/
-.it-mini-player {
+html[it-mini-player='true'] .it-mini-player {
 	z-index: 2201 !important;
 }
 /*--------------------------------------------------------------


### PR DESCRIPTION
The custom mini player was being covered by page content (comments section, recommended videos) when scrolling down. This fix adds a high `z-index` to `.it-mini-player` to ensure it always renders above other page elements, matching the behavior expected from a floating mini player.

Addresses #3494.