### PR TITLE
Fix playlist up next autoplay

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -481,9 +481,16 @@ document.addEventListener('it-message-from-extension', function () {
 				case 'playerHideControls':
 					ImprovedTube.playerControls();
 					break
-				case 'playerlistUpNextAutoplay':
+				case 'playlistUpNextAutoplay':
 					if (this.storage.playlist_up_next_autoplay !== false) {
-						if (playlistData.currentIndex != playlistData.localCurrentIndex) { playlistData.currentIndex = playlistData.localCurrentIndex; }
+						// Autoplay enabled -> resync indices and start the large playlist handler
+						const pData = ImprovedTube.elements.ytd_watch?.playlistData;
+						if (pData && pData.currentIndex != pData.localCurrentIndex) { pData.currentIndex = pData.localCurrentIndex; }
+						ImprovedTube.playlistLargePlaylistHandler();
+					} else {
+						// Autoplay disabled -> clean up sync handlers and apply disable
+						ImprovedTube.cleanupPlaylistHandlers();
+						ImprovedTube.playlistUpNextAutoplay();
 					}
 					break
 				case 'playlistCopyVideoId':

--- a/js&css/web-accessible/www.youtube.com/playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist.js
@@ -4,73 +4,51 @@
 /*------------------------------------------------------------------------------
 4.5.1 UP NEXT AUTOPLAY
 ------------------------------------------------------------------------------*/
-ImprovedTube.playlistUpNextAutoplay = function () { 
+ImprovedTube.playlistUpNextAutoplay = function () {
 	if (this.storage.playlist_up_next_autoplay === false) {
 		const playlistData = this.elements.ytd_watch?.playlistData;
 		if (this.getParam(location.href, 'list') && playlistData
 			&& playlistData.currentIndex
 			&& playlistData.totalVideos
 			&& playlistData.localCurrentIndex) {
-			
-			// Fix for large playlists: ensure proper synchronization instead of forcing end
-			// YouTube loads playlists in chunks (typically 200 videos), so we need to 
-			// keep currentIndex and localCurrentIndex in sync as new segments load
-			if (playlistData.currentIndex !== playlistData.localCurrentIndex) {
-				playlistData.currentIndex = playlistData.localCurrentIndex;
-			}
-			
-			// Monitor for playlist data updates to handle pagination
-			if (!this.playlistAutoplayObserver) {
-				this.playlistAutoplayObserver = new MutationObserver((mutations) => {
-					mutations.forEach((mutation) => {
-						if (mutation.type === 'attributes' && 
-							mutation.attributeName === 'data' && 
-							this.elements.ytd_watch?.playlistData) {
-							
-							const updatedData = this.elements.ytd_watch.playlistData;
-							// Resync when YouTube loads new playlist segments
-							if (updatedData.currentIndex !== updatedData.localCurrentIndex) {
-								updatedData.currentIndex = updatedData.localCurrentIndex;
-							}
-						}
-					});
-				});
-				
-				// Observe the watch element for playlist data changes
-				if (this.elements.ytd_watch) {
-					this.playlistAutoplayObserver.observe(this.elements.ytd_watch, {
-						attributes: true,
-						attributeFilter: ['data']
-					});
-				}
-			}
-		}
-	} else {
-		// Clean up observer when feature is enabled
-		if (this.playlistAutoplayObserver) {
-			this.playlistAutoplayObserver.disconnect();
-			this.playlistAutoplayObserver = null;
+			// Prevent autoplay by telling YouTube we're at the end of the playlist
+			playlistData.currentIndex = playlistData.totalVideos;
 		}
 	}
 };
 
-// Enhanced playlist navigation handler for large playlists
+// Playlist navigation handler for large playlists (400+ videos).
+// YouTube loads playlist metadata in chunks (~200 videos), causing
+// currentIndex and localCurrentIndex to desync at chunk boundaries.
+// This handler keeps them in sync so autoplay continues working.
+// Only runs when playlist_up_next_autoplay is NOT disabled.
 ImprovedTube.playlistLargePlaylistHandler = function() {
 	if (!this.getParam(location.href, 'list')) return;
-	
+
+	// Do not sync indices if the user has disabled playlist autoplay,
+	// because playlistUpNextAutoplay intentionally sets currentIndex
+	// to totalVideos to prevent the next video from playing.
+	if (this.storage.playlist_up_next_autoplay === false) {
+		this.cleanupPlaylistHandlers();
+		return;
+	}
+
 	const playlistData = this.elements.ytd_watch?.playlistData;
 	if (!playlistData) return;
-	
+
 	// Monitor video changes to handle large playlist navigation
 	const videoElement = this.elements.player?.querySelector('video');
 	if (videoElement && !this.playlistVideoChangeListener) {
 		this.playlistVideoChangeListener = () => {
+			// Re-check the setting in case it changed mid-session
+			if (this.storage.playlist_up_next_autoplay === false) return;
+
 			setTimeout(() => {
 				const currentData = this.elements.ytd_watch?.playlistData;
 				if (currentData && currentData.currentIndex !== currentData.localCurrentIndex) {
-					// Force synchronization when video changes
+					// Sync indices when YouTube loads new playlist segments
 					currentData.currentIndex = currentData.localCurrentIndex;
-					
+
 					// Update the player's playlist manager if available
 					const playlistManager = document.querySelector('yt-playlist-manager');
 					if (playlistManager && playlistManager.autoplayData) {
@@ -79,23 +57,24 @@ ImprovedTube.playlistLargePlaylistHandler = function() {
 				}
 			}, 100);
 		};
-		
+
 		videoElement.addEventListener('loadedmetadata', this.playlistVideoChangeListener);
 		videoElement.addEventListener('play', this.playlistVideoChangeListener);
 	}
-	
-	// Cleanup function for when navigating away from playlist pages
-	this.cleanupPlaylistHandlers = function() {
-		if (this.playlistAutoplayObserver) {
-			this.playlistAutoplayObserver.disconnect();
-			this.playlistAutoplayObserver = null;
-		}
-		if (this.playlistVideoChangeListener && videoElement) {
-			videoElement.removeEventListener('loadedmetadata', this.playlistVideoChangeListener);
-			videoElement.removeEventListener('play', this.playlistVideoChangeListener);
-			this.playlistVideoChangeListener = null;
-		}
-	};
+};
+
+// Cleanup function for when navigating away from playlist pages
+ImprovedTube.cleanupPlaylistHandlers = function() {
+	if (this.playlistAutoplayObserver) {
+		this.playlistAutoplayObserver.disconnect();
+		this.playlistAutoplayObserver = null;
+	}
+	const videoElement = this.elements.player?.querySelector('video');
+	if (this.playlistVideoChangeListener && videoElement) {
+		videoElement.removeEventListener('loadedmetadata', this.playlistVideoChangeListener);
+		videoElement.removeEventListener('play', this.playlistVideoChangeListener);
+		this.playlistVideoChangeListener = null;
+	}
 };
 /*------------------------------------------------------------------------------
 4.5.2 REVERSE


### PR DESCRIPTION
Playlist up next autoplay was broken for playlists with >400 videos as reported in https://github.com/code-charity/youtube/issues/3541



A fix was attempted in https://github.com/code-charity/youtube/commit/c7a8a9ceca98a76045acb8d9c53c322d8422236c which was merged in February 2026. This commit instead broke the functionality of the playlist up next autoplay feature and locked it to an always-on state.



This commit fixes both the original issue and the new issue encountered in https://github.com/code-charity/youtube/issues/3627



* Fixed the incorrect call to non-existent `playerlistUpNextAutoplay` function that is now correctly mapped to `playlistUpNextAutoplay`
* Changed the functionality of `playlistUpNextAutoplay` to properly handle both cases for the `playlist\_up\_next\_autoplay` flag.

  * If set to enabled/true, then this function runs and syncs the local and current indices
  * If set to disabled/false, the current playlist index is saved to the local index variable, and the current local index is then set to the end of the playlist. This tricks YouTube into thinking the playlist has reached the end and does not trigger playing the next video in the playlist (because it thinks there are no more videos after the current one)

