### PR TITLE
Fix play not working first time on autoplayDisabled

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -7,9 +7,7 @@ ImprovedTube.autoplayDisable = function (videoElement) {
 		|| this.storage.channel_trailer_autoplay === false) {
 		const player = this.elements.player || videoElement.closest('.html5-video-player') || videoElement.closest('#movie_player'); // #movie_player: outdated since 2024?
 
-		if (this.video_url !== location.href) {	this.user_interacted = false; }
-
-		//if (there is a player) and (no user clicks) and (no ads playing) 
+		//if (there is a player) and (no user clicks) and (no ads playing)
 		// and( ((auto play is off and it is not in a playlist)
 		//   	 or (playlist auto play is off and in a playlist))
 		//   	 or (we are in a channel and the channel trailer autoplay is off)  )


### PR DESCRIPTION
Beware reviewer, this was done with Claude Code with very minor testing, needs scrutiny.

If autoplay is disabled in settings, then opening any video will not autoplay (thats ok), but pressing play will NOT not actually start playing video (not okay). It requires after to press pause first, then play second just to make video starting to play. This is extremely annoying and what have discouraged me from using this extension earlier.

From claude:
> Why: When the user clicks play, mousedown sets user_interacted = true. But autoplayDisable() is called inside the .play() interceptor, and this line would immediately reset user_interacted = false (because video_url hadn't been updated yet by initPlayer()). Then a setTimeout would call pauseVideo(), freezing the video. The user had to click pause then play again because on the second attempt, video_url already matched location.href, so the reset didn't trigger.
>
> Why it's safe to remove: initPlayer() in functions.js:394-396 already resets user_interacted = false and updates video_url on every navigation via yt-navigate-finish. This line was a redundant reset that created a race condition with the mousedown listener.