### PR TITLE
Fix #3745: autodubbing when miniplayer

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1493,6 +1493,12 @@ ImprovedTube.miniPlayer_scroll = function () {
 
 		ImprovedTube.mini_player__setSize(ImprovedTube.mini_player__width, ImprovedTube.mini_player__height, true, true);
 
+		// Re-apply disableAutoDubbing when entering mini player mode
+		// (YouTube may reset audio track when switching to mini player)
+		if (ImprovedTube.storage.disable_auto_dubbing === true) {
+			ImprovedTube.disableAutoDubbing();
+		}
+
 		window.addEventListener('mousedown', ImprovedTube.miniPlayer_mouseDown);
 		window.addEventListener('mousemove', ImprovedTube.miniPlayer_cursorUpdate);
 		window.addEventListener('resize', ImprovedTube.miniPlayer_scroll);
@@ -1508,6 +1514,12 @@ ImprovedTube.miniPlayer_scroll = function () {
 		document.documentElement.removeAttribute('it-mini-player-cursor');
 
 		window.dispatchEvent(new Event('resize'));
+
+		// Re-apply disableAutoDubbing when exiting mini player mode
+		// (YouTube may reset audio track when switching back to normal player)
+		if (ImprovedTube.storage.disable_auto_dubbing === true) {
+			ImprovedTube.disableAutoDubbing();
+		}
 
 		window.removeEventListener('mousedown', ImprovedTube.miniPlayer_mouseDown);
 		window.removeEventListener('mousemove', ImprovedTube.miniPlayer_mouseMove);


### PR DESCRIPTION
## Description
Fixes #3745

### Problem
When users enter mini player mode (pressing i key or scrolling), YouTube resets the audio track to the first dubbing option, even when "Disable auto dubbing" is enabled.

### Solution
This PR adds calls to disableAutoDubbing() when entering and exiting mini player mode in the miniPlayer_scroll function:

1. When entering mini player mode (scrollY >= 256)
2. When exiting mini player mode (scrollY < 256)

This ensures that the audio track is re-applied after YouTube potentially resets it during mini player transitions.

### Testing
- Enable "Disable auto dubbing" in ImprovedTube settings
- Play a video with multiple audio tracks
- Press i or scroll down to enter mini player mode
- Audio track should remain on the original track instead of switching to the first option

### Files Changed
- js&css/web-accessible/www.youtube.com/player.js: Added disableAutoDubbing calls in miniPlayer_scroll function (+12 lines)