### PR TITLE
Fix #3745: autodubbing when miniplayer

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1493,6 +1493,12 @@ ImprovedTube.miniPlayer_scroll = function () {
 
 		ImprovedTube.mini_player__setSize(ImprovedTube.mini_player__width, ImprovedTube.mini_player__height, true, true);
 
+		// Re-apply disableAutoDubbing when entering mini player mode
+		// (YouTube may reset audio track when switching to mini player)
+		if (ImprovedTube.storage.disable_auto_dubbing === true) {
+			ImprovedTube.disableAutoDubbing();
+		}
+
 		window.addEventListener('mousedown', ImprovedTube.miniPlayer_mouseDown);
 		window.addEventListener('mousemove', ImprovedTube.miniPlayer_cursorUpdate);
 		window.addEventListener('resize', ImprovedTube.miniPlayer_scroll);
@@ -1508,6 +1514,12 @@ ImprovedTube.miniPlayer_scroll = function () {
 		document.documentElement.removeAttribute('it-mini-player-cursor');
 
 		window.dispatchEvent(new Event('resize'));
+
+		// Re-apply disableAutoDubbing when exiting mini player mode
+		// (YouTube may reset audio track when switching back to normal player)
+		if (ImprovedTube.storage.disable_auto_dubbing === true) {
+			ImprovedTube.disableAutoDubbing();
+		}
 
 		window.removeEventListener('mousedown', ImprovedTube.miniPlayer_mouseDown);
 		window.removeEventListener('mousemove', ImprovedTube.miniPlayer_mouseMove);


### PR DESCRIPTION
Fixes #3745

**Problem:**
YouTube resets the audio track during mini player transitions, causing autodubbing to be interrupted.

**Solution:**
- Add `disableAutoDubbing` call when entering mini player mode
- Add `disableAutoDubbing` call when exiting mini player mode
- Prevents YouTube from resetting audio track during mini player transitions

**Changes:**
- Modified `js&css/web-accessible/www.youtube.com/player.js`
- Added 12 lines of code to handle mini player transitions

**Testing:**
- Verified that autodubbing works correctly during mini player transitions
- Tested entering and exiting mini player mode multiple times
- Confirmed audio track remains stable throughout transitions