### PR TITLE
fix(locale): add English name for preferredDubbingLanguage in _locales/en/messages.json

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,1670 +1,1670 @@
 {
-	"preferredDubbingLanguage": {
+  "preferredDubbingLanguage": {
 		"message": "Preferred dubbing language"
 	},
-	"hideSuggestedAction": {
-		"message": "Hide Suggested Action 'View products'"
-	},
-	"hideMerchShelf": {
-		"message": "Hide 'Merch Shelf'"
-	},
-	"about": {
-		"message": "About"
-	},
-	"accept": {
-		"message": "Accept"
-	},
-	"activate": {
-		"message": "Activate"
-	},
-	"activateCaptions": {
-		"message": "Activate captions"
-	},
-	"activated": {
-		"message": "Activated"
-	},
-	"activatedFeatures": {
-		"message": "Activated features"
-	},
-	"activateFitToWindow": {
-		"message": "Fit to window"
-	},
-	"activateFullscreen": {
-		"message": "Fullscreen"
-	},
-	"activeFeatures": {
-		"message": "My active features"
-	},
-	"addScrollToTop": {
-		"message": "Add «Scroll to top»"
-	},
-	"ads": {
-		"message": "Video Ads"
-	},
-	"all": {
-		"message": "All"
-	},
-	"allow": {
-		"message": "Allow"
-	},
-	"Allow_auto_generate": {
-		"message": "Allow auto generation"
-	},
-	"allow60fps": {
-		"message": "Allow 60fps"
-	},
-	"allYourSettingsWillBeErasedAndCanTBeRecovered": {
-		"message": "All your settings will be erased and can't be recovered"
-	},
-	"allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-		"message": "All your shortcuts will be erased and can't be recovered"
-	},
-	"always": {
-		"message": "Always"
-	},
-	"alwaysActive": {
-		"message": "Always active"
-	},
-	"alwaysShowProgressBar": {
-		"message": "Always show Progress Bar"
-	},
-	"amber": {
-		"message": "Amber"
-	},
-	"ambientLighting": {
-		"message": "Ambient lighting"
-	},
-	"analytics": {
-		"message": "Analytics"
-	},
-	"analyzer": {
-		"message": "Analyzer"
-	},
-	"animations": {
-		"message": "Animations"
-	},
-	"appearance": {
-		"message": "Appearance"
-	},
-	"areYouSureYouWantToExportTheData": {
-		"message": "Are you sure you want to export the data?"
-	},
-	"areYouSureYouWantToImportTheData": {
-		"message": "Are you sure you want to import this data?"
-	},
-	"areYouSureYouWantToSyncTheData": {
-		"message": "Are you sure you want to sync the current settings?"
-	},
-	"ARROWDOWN": {
-		"message": "⇩"
-	},
-	"ARROWLEFT": {
-		"message": "⇦"
-	},
-	"ARROWRIGHT": {
-		"message": "⇨"
-	},
-	"ARROWUP": {
-		"message": "⇧"
-	},
-	"ask": {
-		"message": "Ask"
-	},
-	"atHistory": {
-		"message": "at 'History'"
-	},
-	"atSubscriptions": {
-		"message": "at 'Subscriptions'"
-	},
-	"atTrending": {
-		"message": "at 'Trending'"
-	},
-	"audio": {
-		"message": "Audio"
-	},
-	"audioFormats": {
-		"message": "Audio formats"
-	},
-	"auto": {
-		"message": "Auto"
-	},
-	"Auto_PiP_picture_in_picture": {
-		"message": "Auto-PiP (Picture in Picture)"
-	},
-	"autoFullscreen": {
-		"message": "Auto-fullscreen"
-	},
-	"autopauseWhenSwitchingTabs": {
-		"message": "Auto-pause while I'm not in the tab"
-	},
-	"autoPictureInPicture": {
-		"message": "Auto Picture-In-Picture"
-	},
-	"autoplay": {
-		"message": "Autoplay"
-	},
-	"autoplayDisable": {
-		"message": "Force Autoplay Off"
-	},
-	"autoPlayNextShort": {
-		"message": "Shorts up next autoplay"
-	},
-	"avoidAv1": {
-		"message": "Avoid AV1"
-	},
-	"avoidAv1Vp8Vp9": {
-		"message": "Avoid AV1, VP8, VP9"
-	},
-	"avoidAv1Vp9": {
-		"message": "Avoid AV1, VP9"
-	},
-	"avoidCpuRenderingWhenPossible": {
-		"message": "Avoid CPU rendering when possible"
-	},
-	"backgroundColor": {
-		"message": "Background Color"
-	},
-	"backgroundOpacity": {
-		"message": "Background Opacity"
-	},
-	"backupAndReset": {
-		"message": "Backup & Reset"
-	},
-	"baseOnSystemColorScheme": {
-		"message": "Base on System Color Scheme"
-	},
-	"belowPlayer": {
-		"message": "Below Player"
-	},
-	"bitness": {
-		"message": "Bitness"
-	},
-	"black": {
-		"message": "Black"
-	},
-	"block_Codec_Alert_h264": {
-		"message": "You need either H.264 or VP9 enabled for Youtube to play videos."
-	},
-	"block_Codec_Alert_VP9": {
-		"message": "You need either VP9 or H.264 enabled for Youtube to play videos."
-	},
-	"blockAll": {
-		"message": "Off (block or skip)"
-	},
-	"blockAv1": {
-		"message": "Block AV1"
-	},
-	"blockH264": {
-		"message": "Block H.264"
-	},
-	"blocklist": {
-		"message": "Blocklist"
-	},
-	"blockMusic": {
-		"message": "Skip Ads while I play music"
-	},
-	"blockVp8": {
-		"message": "Block VP8"
-	},
-	"blockVp9": {
-		"message": "Block VP9"
-	},
-	"blue": {
-		"message": "Blue"
-	},
-	"blueGray": {
-		"message": "Blue gray"
-	},
-	"bluelight": {
-		"message": "Bluelight"
-	},
-	"bottomLeft": {
-		"message": "Bottom left"
-	},
-	"bottomRight": {
-		"message": "Bottom right"
-	},
-	"brightness": {
-		"message": "Brightness"
-	},
-	"brown": {
-		"message": "Brown"
-	},
-	"browser": {
-		"message": "Browser"
-	},
-	"browserAccountSync": {
-		"message": "Sync (Browser Account)"
-	},
-	"browserVersion": {
-		"message": "Browser Version"
-	},
-	"bubbles": {
-		"message": "Bubbles"
-	},
-	"bug": {
-		"message": "Bug"
-	},
-	"bulkDeleteByProgress": {
-		"message": "Bulk delete videos by watch progress"
-	},
-	"buttons": {
-		"message": "Buttons"
-	},
-	"cancel": {
-		"message": "Cancel"
-	},
-	"categories": {
-		"message": "Categories"
-	},
-	"categoryRefreshButton": {
-		"message": "Add category refresh button"
-	},
-	"changeThumbnailsPerRow": {
-		"message": "Thumbnails per Row"
-	},
-	"channel": {
-		"message": "Channel"
-	},
-	"channels": {
-		"message": "Channels"
-	},
-	"chapters": {
-		"message": "Chapters"
-	},
-	"chapterTitle": {
-		"message": "Chapter Title"
-	},
-	"characterEdgeStyle": {
-		"message": "Character Edge Style"
-	},
-	"cinemaMode": {
-		"message": "Cinema Mode"
-	},
-	"clickableLinksInDescription": {
-		"message": "Right click to copy links in video descriptions"
-	},
-	"clip": {
-		"message": "Clip"
-	},
-	"clipboard": {
-		"message": "Clipboard"
-	},
-	"codecH264": {
-		"message": "Codec h.264"
-	},
-	"codecs": {
-		"message": "Codecs"
-	},
-	"collapsed": {
-		"message": "Collapsed"
-	},
-	"collapseOfSubscriptionSections": {
-		"message": "Fold subscriptions' sections (collapsed accordion)"
-	},
-	"columns": {
-		"message": "Extra sidebar column (without moving the related videos, if the window is wide enough)"
-	},
-	"comments": {
-		"message": "Comments"
-	},
-	"compact_spacing": {
-		"message": "Compact Spacing"
-	},
-	"compactTheme": {
-		"message": "Compact Theme"
-	},
-	"confirmationBeforeClosing": {
-		"message": "Confirmation before closing"
-	},
-	"cookies": {
-		"message": "Cookies"
-	},
-	"copyVideoId": {
-		"message": "📋 Copy Video ID"
-	},
-	"copyVideoUrl": {
-		"message": "Copy Video Full URL"
-	},
-	"copyTranscript": {
-		"message": "📋 Copy Transcript"
-	},
-	"FetchingTranscript": {
-		"message": "Fetching..."
-	},
-	"TranscriptError": {
-		"message": "Error"
-	},
-	"cores": {
-		"message": "Cores"
-	},
-	"cropChapterTitles": {
-		"message": "Crop Chapter Titles"
-	},
-	"Currently_requiring_a_YouTube_API_key": {
-		"message": "(Currently requiring a YouTube-API-key: )"
-	},
-	"cursorLighting": {
-		"message": "Dim Youtube's Pages, except what I mouse-over!"
-	},
-	"custom": {
-		"message": "Custom"
-	},
-	"customCss": {
-		"message": "Custom CSS"
-	},
-	"customJs": {
-		"message": "Custom JS"
-	},
-	"customMiniPlayer": {
-		"message": "Custom Mini-Player"
-	},
-	"cyan": {
-		"message": "Cyan"
-	},
-	"dark": {
-		"message": "Dark"
-	},
-	"darkTheme": {
-		"message": "Dark theme"
-	},
-	"dateAndTime": {
-		"message": "Date & time"
-	},
-	"dawn": {
-		"message": "Dawn"
-	},
-	"decreasePlaybackSpeed": {
-		"message": "Decrease Playback Speed"
-	},
-	"decreaseVolume": {
-		"message": "Decrease Volume"
-	},
-	"deepOrange": {
-		"message": "Deep Orange"
-	},
-	"deepPurple": {
-		"message": "Deep Purple"
-	},
-	"default": {
-		"message": "Default"
-	},
-	"default_CC": {
-		"message": "default"
-	},
-	"default_theme": {
-		"message": "default"
-	},
-	"defaultChannelTab": {
-		"message": "Default channel tab"
-	},
-	"defaultContentCountry": {
-		"message": "Country (virtual travel)"
-	},
-	"defaultPlaybackSpeed": {
-		"message": "Default Playback Speed"
-	},
-	"deleteWatchedVideos": {
-		"message": "Delete watched videos"
-	},
-	"deleteYoutubeCookies": {
-		"message": "Delete YouTube cookies"
-	},
-	"depressed": {
-		"message": "Depressed"
-	},
-	"description": {
-		"message": "Description"
-	},
-	"disableSidebarScroll": {
-		"message": "Disable sidebar scroll"
-	},
-	"description_ext": {
-		"message": "YouTube, tidy & smart? Supercharge YouTube! Give it strong features, filter only the videos you want & exactly the look you like"
-	},
-	"desert": {
-		"message": "Desert"
-	},
-	"details": {
-		"message": "Details"
-	},
-	"developerOptions": {
-		"message": "Developer options"
-	},
-	"device": {
-		"message": "Device"
-	},
-	"dim": {
-		"message": "Dim"
-	},
-	"disableAutoDubbing": {
-		"message": "Disable auto dubbing"
-	},
-	"disabled": {
-		"message": "Disabled"
-	},
-	"disableLikesAnimation": {
-		"message": "Disable likes animation"
-	},
-	"disableThumbnailPlayback": {
-		"message": "Disable video playback on hover"
-	},
-	"muteThumbnailPreviews": {
-		"message": "Mute thumbnail previews"
-	},
-	"dislike": {
-		"message": "Dislike"
-	},
-	"dislikingAVideoAddsItToBlocklist": {
-		"message": "Disliking a video adds it to Blocklist"
-	},
-	"displayDayOfTheWeak": {
-		"message": "Display day of the week"
-	},
-	"donate": {
-		"message": "Donate"
-	},
-	"doNotChange": {
-		"message": "Don't change"
-	},
-	"download": {
-		"message": "Download"
-	},
-	"draggable": {
-		"message": "Draggable"
-	},
-	"dropShadow": {
-		"message": "Drop shadow"
-	},
-	"durationWithSpeed": {
-		"message": "Show time remaining with reference to playback speed"
-	},
-	"email": {
-		"message": "Email"
-	},
-	"embedded_Hide_Share": {
-		"message": "Embedded Hide Share"
-	},
-	"Embedded_YouTube": {
-		"message": "Embedded YouTube"
-	},
-	"empty": {
-		"message": "Empty"
-	},
-	"enabled": {
-		"message": "Enabled"
-	},
-	"enabledForced": {
-		"message": "Enabled (forced)"
-	},
-	"enterPassword": {
-		"message": "Please enter your 4-digit code."
-	},
-	"exact": {
-		"message": "Exact date/time"
-	},
-	"excludeShortsInPlayAll": {
-		"message": "Exclude Shorts when using \"Play all\""
-	},
-	"expanded": {
-		"message": "Expanded"
-	},
-	"exportSettings": {
-		"message": "Export settings"
-	},
-	"extension": {
-		"message": "Extension"
-	},
-	"ExtraButtons": {
-		"message": "Extra buttons"
-	},
-	"extraButtonsBelowThePlayer": {
-		"message": "Extra buttons below the player"
-	},
-	"extraRightControlButtons": {
-		"message": "Extra buttons inside the player"
-	},
-	"Feature_not_yet_available": {
-		"message": "Feature not yet available"
-	},
-	"file": {
-		"message": "File"
-	},
-	"filters": {
-		"message": "Filters"
-	},
-	"fitToWindow": {
-		"message": "Old alternative ('Fit to window')"
-	},
-	"flash": {
-		"message": "Flash"
-	},
-	"font": {
-		"message": "Font"
-	},
-	"fontColor": {
-		"message": "Font color"
-	},
-	"fontFamily": {
-		"message": "Font family"
-	},
-	"fontOpacity": {
-		"message": "Font opacity"
-	},
-	"fontSize": {
-		"message": "Font size"
-	},
-	"footer": {
-		"message": "Footer"
-	},
-	"forcedPlaybackSpeed": {
-		"message": "Speed-watching: Permanent Speed"
-	},
-	"forcedPlaybackSpeedMusic": {
-		"message": "(Force playback speed even for music?)"
-	},
-	"forcedPlayVideoFromTheBeginning": {
-		"message": "Force video to play from the beginning"
-	},
-	"forcedTheaterMode": {
-		"message": "Force Theater Mode"
-	},
-	"forcedVolume": {
-		"message": "Force Volume"
-	},
-	"forceSDR": {
-		"message": "Avoid HDR, keep SDR"
-	},
-	"foundABug": {
-		"message": "Found a bug?"
-	},
-	"fullScreenQuality": {
-		"message": "Fullscreen quality"
-	},
-	"fullscreenReturn": {
-		"message": "Fullscreen return"
-	},
-	"fullWindow": {
-		"message": "Full height"
-	},
-	"general": {
-		"message": "General"
-	},
-	"geoPreference": {
-		"message": "Geo Preference"
-	},
-	"github": {
-		"message": "GitHub"
-	},
-	"googleApiKey": {
-		"message": "Google API key"
-	},
-	"goToSearchBox": {
-		"message": "Go to search box"
-	},
-	"gpu": {
-		"message": "GPU"
-	},
-	"GPUnotindatabase": {
-		"message": "GPU not in database"
-	},
-	"green": {
-		"message": "Green"
-	},
-	"grey": {
-		"message": "Grey"
-	},
-	"halfTransparent": {
-		"message": "Faint/half-transparent"
-	},
-	"Hamburger_Menu": {
-		"message": "Hamburger Menu"
-	},
-	"hardwareInformation": {
-		"message": "Hardware information"
-	},
-	"hd": {
-		"message": "HD"
-	},
-	"hdThumbnail": {
-		"message": "HD thumbnail"
-	},
-	"header": {
-		"message": "Header"
-	},
-	"hidden": {
-		"message": "Hidden"
-	},
-	"hiddenOnVideoPage": {
-		"message": "Hidden on video page"
-	},
-	"hide_author_avatars": {
-		"message": "Hide author avatars"
-	},
-	"hide_labels": {
-		"message": "Hide names"
-	},
-	"Hide_Pause_Overlay": {
-		"message": "Hide Pause Overlay"
-	},
-	"Hide_Shorts_remixing_this_video": {
-		"message": "Hide Shorts remixing this video"
-	},
-	"Hide_sidebar": {
-		"message": "Hide sidebar "
-	},
-	"Hide_the_tabs_only": {
-		"message": "Hide the tabs only"
-	},
-	"Hide_YouTube_Logo": {
-		"message": "Hide YouTube Logo"
-	},
-	"hideAISummary": {
-		"message": "Hide AI Summaries"
-	},
-	"hideAnimatedThumbnails": {
-		"message": "Hide animated thumbnails"
-	},
-	"hideAnnotations": {
-		"message": "Hide annotations"
-	},
-	"hideBannerAds": {
-		"message": "Hide Banner Ads (YouTube might deny)"
-	},
-	"hideCards": {
-		"message": "Hide cards"
-	},
-	"hideCategories": {
-		"message": "Hide categories"
-	},
-	"hideCommentsCount": {
-		"message": "Hide comments count"
-	},
-	"hideCountryCode": {
-		"message": "Hide country code"
-	},
-	"hideDate": {
-		"message": "Hide date"
-	},
-	"hideDetailButton": {
-		"message": "Buttons (below the player)"
-	},
-	"hideDetails": {
-		"message": "Hide details"
-	},
-	"hideEndscreen": {
-		"message": "Hide endscreen"
-	},
-	"hideFeaturedContent": {
-		"message": "Hide featured content"
-	},
-	"hideFooter": {
-		"message": "Hide footer"
-	},
-	"hideGradientBottom": {
-		"message": "Hide shadow around player-bar"
-	},
-	"hideHomePageShorts": {
-		"message": "Hide Shorts on the home page"
-	},
-	"hideIncludesPaidPromotion": {
-		"message": "Hide \"Includes Paid Promotion\""
-	},
-	"hideLogo": {
-		"message": "Logo: Hide!"
-	},
-	"hideMore": {
-		"message": "Hide '...'"
-	},
-	"hidePlayerControlsBar": {
-		"message": "Hide player controls bar"
-	},
-	"hidePlayerControlsBarButtons": {
-		"message": "Hide player controls buttons"
-	},
-	"hidePlayerControlsBarOptions": {
-		"message": "Hide player controls options"
-	},
-	"hidePlaylist": {
-		"message": "Hide playlist"
-	},
-	"hideProgressBarPreview": {
-		"message": "Hide progress bar preview"
-	},
-	"hideReport": {
-		"message": "Hide 'Report'"
-	},
-	"hideRightButtons": {
-		"message": "Hide right buttons"
-	},
-	"hideScrollForDetails": {
-		"message": "Hide «Scroll for details»"
-	},
-	"hideSkipOverlay": {
-		"message": "Hide 5 second skip animation"
-	},
-	"hideSponsoredVideosOnHome": {
-		"message": "Hide sponsored videos on Home page"
-	},
-	"hidePauseOverlay": {
-		"message": "Hide Pause Overlay"
-	},
-	"hideThumbnailDots": {
-		"message": "Hide '⫶' (more actions) on thumbnails"
-	},
-	"hideThumbnailIcon": {
-		"message": "Hide thumbnail icon"
-	},
-	"hideThumbnailOverlay": {
-		"message": "Hide buttons on thumbnails"
-	},
-	"hideThumbnails": {
-		"message": "Hide thumbnails"
-	},
-	"hideTopLoadingBar": {
-		"message": "Hide Top Loading Bar"
-	},
-	"hideVideoTitleFullScreen": {
-		"message": "Hide video title in fullscreen"
-	},
-	"hideViewsCount": {
-		"message": "Hide views count"
-	},
-	"hideVoiceSearchButton": {
-		"message": "Hide voice search button"
-	},
-	"hideWatchedVideos": {
-		"message": "Hide watched videos"
-	},
-	"high": {
-		"message": "High"
-	},
-	"history": {
-		"message": "History"
-	},
-	"home": {
-		"message": "Home"
-	},
-	"homeScreen": {
-		"message": "Home screen"
-	},
-	"hover": {
-		"message": "Hover"
-	},
-	"hoverOnVideoPage": {
-		"message": "Hover on video page"
-	},
-	"howLongAgoTheVideoWasUploaded": {
-		"message": "Show video's age (how long ago it was uploaded)"
-	},
-	"icons": {
-		"message": "Icons"
-	},
-	"iconsOnly": {
-		"message": "Icon only"
-	},
-	"importSettings": {
-		"message": "Import settings"
-	},
-	"ImprovedTube": {
-		"message": "ImprovedTube"
-	},
-	"improvedtubeButtons": {
-		"message": "ImprovedTube buttons"
-	},
-	"improvedtubeIconOnYoutube": {
-		"message": "ImprovedTube icon on YouTube"
-	},
-	"improvedtubeLanguage": {
-		"message": "ImprovedTube"
-	},
-	"improvedTubeSidePanel": {
-		"message": "ImprovedTube: Browser Sidepanel"
-	},
-	"improvedtubeVersion": {
-		"message": "ImprovedTube version"
-	},
-	"improveLogo": {
-		"message": "Logo: Monochrome!"
-	},
-	"increasePlaybackSpeed": {
-		"message": "Increase playback speed"
-	},
-	"increaseVolume": {
-		"message": "Increase volume"
-	},
-	"indigo": {
-		"message": "Indigo"
-	},
-	"items": {
-		"message": "Items"
-	},
-	"join": {
-		"message": "Join"
-	},
-	"keyScene": {
-		"message": "⚡Jump to the Most Replayed Scene/s"
-	},
-	"language": {
-		"message": "Language"
-	},
-	"language_closed_caption": {
-		"message": "Language Default - Closed Captions"
-	},
-	"languages": {
-		"message": "Languages"
-	},
-	"lastWatchedFormat": {
-		"message": "Time format"
-	},
-	"lastWatchedOverlayPosition": {
-		"message": "Overlay position"
-	},
-	"layerAnimationScale": {
-		"message": "Layer animation scale"
-	},
-	"layout": {
-		"message": "Layout"
-	},
-	"Left_Side_Menu": {
-		"message": "Left Side Menu"
-	},
-	"legacyYoutube": {
-		"message": "Legacy YouTube"
-	},
-	"library": {
-		"message": "Library"
-	},
-	"light": {
-		"message": "Light"
-	},
-	"lightBlue": {
-		"message": "Light blue"
-	},
-	"lightGreen": {
-		"message": "Light green"
-	},
-	"like": {
-		"message": "Like"
-	},
-	"liked": {
-		"message": "Liked"
-	},
-	"likes": {
-		"message": "Likes"
-	},
-	"lime": {
-		"message": "Lime"
-	},
-	"limitPageWidth": {
-		"message": "Limit page width"
-	},
-	"list": {
-		"message": "List"
-	},
-	"liveChat": {
-		"message": "Live chat"
-	},
-	"liveChatType": {
-		"message": "Live chat type"
-	},
-	"location": {
-		"message": "Location"
-	},
-	"loop": {
-		"message": "🔁 Loop"
-	},
-	"loudnessNormalization": {
-		"message": "Loudness normalization"
-	},
-	"low": {
-		"message": "Low"
-	},
-	"markWatchedVideos": {
-		"message": "Mark watched videos"
-	},
-	"medium": {
-		"message": "Medium"
-	},
-	"mixer": {
-		"message": "Mixer"
-	},
-	"more": {
-		"message": "More"
-	},
-	"mostViewedChannels": {
-		"message": "Most viewed channels"
-	},
-	"moveSidebarLeft": {
-		"message": "To the left!"
-	},
-	"moveThumbnailsRight": {
-		"message": "Thumbnails to the right!"
-	},
-	"My_specs": {
-		"message": "My specs"
-	},
-	"myColors": {
-		"message": "My colors"
-	},
-	"name": {
-		"message": "Name"
-	},
-	"nativeMiniPlayer": {
-		"message": "Native mini player"
-	},
-	"new": {
-		"message": "New"
-	},
-	"nextVideo": {
-		"message": "Next video"
-	},
-	"night": {
-		"message": "Night"
-	},
-	"nightMode": {
-		"message": "Night mode"
-	},
-	"noActiveFeatures": {
-		"message": "No active features"
-	},
-	"none": {
-		"message": "None"
-	},
-	"noOpenVideoTabs": {
-		"message": "No open video tabs"
-	},
-	"normal": {
-		"message": "Normal"
-	},
-	"Not_optimal": {
-		"message": "Not optimal"
-	},
-	"off": {
-		"message": "Off"
-	},
-	"ok": {
-		"message": "Ok"
-	},
-	"old": {
-		"message": "Old"
-	},
-	"onAllVideos": {
-		"message": "On"
-	},
-	"onlyActiveOnYoutube": {
-		"message": "Only active on YouTube"
-	},
-	"onlyOnePlayerInstancePlaying": {
-		"message": "Pause while I watch a 2nd video"
-	},
-	"onSmallCreators": {
-		"message": "Off, except for small channels"
-	},
-	"onSubscribedChannels": {
-		"message": "Off, except on my subscribed channels"
-	},
-	"openNewTab": {
-		"message": "Open in a new tab"
-	},
-	"openPopupPlayer": {
-		"message": "Open video/playlist in a new window"
-	},
-	"Optimal": {
-		"message": "Optimal"
-	},
-	"optimizeCodecForHardwareAcceleration": {
-		"message": "Optimize Codec for hardware acceleration"
-	},
-	"orange": {
-		"message": "Orange"
-	},
-	"os": {
-		"message": "OS"
-	},
-	"other": {
-		"message": "Other"
-	},
-	"outline": {
-		"message": "Outline"
-	},
-	"overlay": {
-		"message": "Overlay"
-	},
-	"passwordOptions": {
-		"message": "Password options"
-	},
-	"pauseWhileIAmTypingOnYouTube": {
-		"message": "Pause when I'm typing on YouTube"
-	},
-	"pauseWhileIUnplugTheCharger": {
-		"message": "Pause when I unplug the charger"
-	},
-	"permissions": {
-		"message": "Permissions"
-	},
-	"pictureInPicture": {
-		"message": "Picture-in-Picture"
-	},
-	"pink": {
-		"message": "Pink"
-	},
-	"PipRequiresUserInteraction": {
-		"message": "PiP requires recent User interaction with source page. This is Chrome Picture-in-Picture API limitations and we cant do anything to bypass it. Works best with Autoplay disabled and manual Play control or deliberately clicking somewhere on the page before switching Tabs."
-	},
-	"plain": {
-		"message": "Plain"
-	},
-	"platform": {
-		"message": "Platform"
-	},
-	"playAllButton": {
-		"message": "\"Play all\"button"
-	},
-	"playbackSpeed": {
-		"message": "Playback speed"
-	},
-	"playbackSpeedButton": {
-		"message": "Playback speed button"
-	},
-	"playbackSpeedHotkey": {
-		"message": "Playback speed hotkeys"
-	},
-	"player": {
-		"message": "Player"
-	},
-	"player_auto_cinema_mode": {
-		"message": "Auto Cinema Mode"
-	},
-	"player_auto_hide_cinema_mode_when_paused": {
-		"message": "Auto Hide Cinema Mode on Pause"
-	},
-	"player_cinema_mode_button": {
-		"message": "Cinema Mode"
-	},
-	"player_dont_speed_education": {
-		"message": "Don't speed up the (rare) category: Education"
-	},
-	"player_fit_to_win_button": {
-		"message": "Fit to window"
-	},
-	"player_playback_speed_button": {
-		"message": "Playback Speed Button"
-	},
-	"player_rewind_and_forward_buttons": {
-		"message": "Rewind/forward buttons"
-	},
-	"player_rotate_button": {
-		"message": "Rotate video"
-	},
-	"playerAutoPipOutside": {
-		"message": "Auto-PiP only outside source Tab"
-	},
-	"playerColor": {
-		"message": "Progress bar color"
-	},
-	"playerIncreaseDecreaseSpeedButtons": {
-		"message": "Increase/Decrease Speed buttons"
-	},
-	"playerPlaybackSpeedStep": {
-		"message": "Playback Speed Step"
-	},
-	"playerSize": {
-		"message": "Player size"
-	},
-	"playlist": {
-		"message": "Playlist"
-	},
-	"playlists": {
-		"message": "Playlists"
-	},
-	"playPause": {
-		"message": "Play / Pause"
-	},
-	"popupAd": {
-		"message": "Pop-up ad: Hide"
-	},
-	"popupPlayer": {
-		"message": "Popup player"
-	},
-	"popupWindowButtons": {
-		"message": "Add a popup-player-button to each thumbnail"
-	},
-	"position": {
-		"message": "Position"
-	},
-	"pressAnyKeyOrScroll": {
-		"message": "Press any key or use mouse wheel."
-	},
-	"pressAnyKeyOrUseMouseWheel": {
-		"message": "Press any key or use mouse wheel"
-	},
-	"preventShortVideoAutoloop": {
-		"message": "Prevent short videos from auto-looping"
-	},
-	"previousVideo": {
-		"message": "Previous video"
-	},
-	"primaryColor": {
-		"message": "Primary color"
-	},
-	"pullSyncSettings": {
-		"message": "Pull"
-	},
-	"purchase": {
-		"message": "Purchase"
-	},
-	"purple": {
-		"message": "Purple"
-	},
-	"pushSyncSettings": {
-		"message": "Push"
-	},
-	"quality": {
-		"message": "Quality"
-	},
-	"qualityWhenRunningOnBattery": {
-		"message": "Quality, when running on battery"
-	},
-	"qualityWithoutFocus": {
-		"message": "Quality without focus"
-	},
-	"quickDeleteShortcut": {
-		"message": "Quick delete shortcut buttons"
-	},
-	"raised": {
-		"message": "Raised"
-	},
-	"ram": {
-		"message": "RAM"
-	},
-	"rateMe": {
-		"message": "Rate me"
-	},
-	"rateUs": {
-		"message": "Rate us"
-	},
-	"red": {
-		"message": "Red"
-	},
-	"redDislikeButton": {
-		"message": "Red when disliked"
-	},
-	"refreshCategories": {
-		"message": "Refresh categories"
-	},
-	"relatedVideos": {
-		"message": "Related videos"
-	},
-	"relative": {
-		"message": "Relative (e.g. 5m ago)"
-	},
-	"remote": {
-		"message": "Play on TV"
-	},
-	"returnYoutubeDislike": {
-		"message": "Return YouTube Dislike"
-	},
-	"returnYoutubeDislikeDescription": {
-		"message": "Display video dislike counts using Return YouTube Dislike API"
-	},
-	"Remove": {
-		"message": "Remove"
-	},
-	"removeBlackBars": {
-		"message": "Remove black bars when full screen"
-	},
-	"removeContextButtons": {
-		"message": "Remove context buttons on shorts"
-	},
-	"removeIcons": {
-		"message": "Remove icons"
-	},
-	"removeMemberOnly": {
-		"message": "Remove member only videos"
-	},
-	"removeName": {
-		"message": "Remove name"
-	},
-	"removeNames": {
-		"message": "Remove names"
-	},
-	"removePlaylistParam": {
-		"message": "Skip playlist when opening videos in new tab"
-	},
-	"removePlayables": {
-		"message": "Hide playables"
-	},
-	"removeRelatedSearchResults": {
-		"message": "Remove related search results"
-	},
-	"removeShortsReelSearchResults": {
-		"message": "Remove Shorts reel from search results"
-	},
-	"removeSubscriptionsMostRelevant": {
-		"message": "Hide 'Most relevant' section on Subscriptions page"
-	},
-	"subscriptionsListLayout": {
-		"message": "List layout on Subscriptions page"
-	},
-	"RemoveSubtitlesForLyrics": {
-		"message": "Remove subtitles for lyrics"
-	},
-	"repeat": {
-		"message": "Repeat"
-	},
-	"report": {
-		"message": "Report"
-	},
-	"requirePassword": {
-		"message": "Require password to change ImprovedTube settings"
-	},
-	"reset": {
-		"message": "Reset"
-	},
-	"resetAllSettings": {
-		"message": "Reset all settings"
-	},
-	"resetAllShortcuts": {
-		"message": "Reset all shortcuts"
-	},
-	"reverse": {
-		"message": "Reverse"
-	},
-	"revertTheaterModeButtonSizes": {
-		"message": "Revert Theater Mode Button Sizes"
-	},
-	"rotate": {
-		"message": "Rotate"
-	},
-	"save": {
-		"message": "Save"
-	},
-	"saveAs": {
-		"message": "Save as"
-	},
-	"schedule": {
-		"message": "Schedule"
-	},
-	"screen": {
-		"message": "Screen"
-	},
-	"screenshot": {
-		"message": "🖼️ Screenshot"
-	},
-	"scrollBar": {
-		"message": "Scroll Bar"
-	},
-	"sd": {
-		"message": "SD"
-	},
-	"search": {
-		"message": "Search"
-	},
-	"searchBarOnly": {
-		"message": "Search bar only"
-	},
-	"secondaryColor": {
-		"message": "Secondary color"
-	},
-	"seekBackward10Seconds": {
-		"message": "Seek backward 10 seconds"
-	},
-	"seekForward10Seconds": {
-		"message": "Seek forward 10 seconds"
-	},
-	"seekNextChapter": {
-		"message": "Seek Next Chapter"
-	},
-	"seekPreviousChapter": {
-		"message": "Seek Previous Chapter"
-	},
-	"settings": {
-		"message": "Settings"
-	},
-	"settingsSuccessfullyImported": {
-		"message": "Settings successfully imported"
-	},
-	"share": {
-		"message": "Share"
-	},
-	"shortcut_chapters": {
-		"message": "Chapters (Sidebar) On/Off"
-	},
-	"shortcut_screenshot": {
-		"message": "Screenshot"
-	},
-	"shortcut_transcript": {
-		"message": "Transcript (Sidebar) On/Off"
-	},
-	"shortcuts": {
-		"message": "Shortcuts"
-	},
-	"ShortsForceTheStandardPlayer": {
-		"message": "Shorts: Force to use the standard player"
-	},
-	"shortsAlwaysShowButtons": {
-		"message": "Shorts Always Show Control Buttons"
-	},
-	"shortsAlwaysShowCaptions": {
-		"message": "Captions Button"
-	},
-	"shortsAlwaysShowFullscreen": {
-		"message": "Fullscreen Button"
-	},
-	"showCardsOnMouseHover": {
-		"message": "Show cards on mouse hover"
-	},
-	"showChannelVideosCount": {
-		"message": "Show channel videos count"
-	},
-	"showExactDate": {
-		"message": "Show Exact Date"
-	},
-	"showLastWatchedOverlay": {
-		"message": "Show 'Last watched' overlay on thumbnails"
-	},
-	"showLess": {
-		"message": "Show less"
-	},
-	"showMore": {
-		"message": "Show more"
-	},
-	"showRemainingDuration": {
-		"message": "Show video remaining duration"
-	},
-	"showVersion": {
-		"message": "Show version"
-	},
-	"shuffle": {
-		"message": "Shuffle"
-	},
-	"sidebar": {
-		"message": "Sidebar"
-	},
-	"Sidebar_simple_alternative": {
-		"message": "Sidebar (simple alternative)"
-	},
-	"smartSpeed": {
-		"message": "Speed up lesser-watched sections"
-	},
-	"softwareInformation": {
-		"message": "Software information"
-	},
-	"spacebar": {
-		"message": "Spacebar"
-	},
-	"squaredUserImages": {
-		"message": "Squared user images"
-	},
-	"static": {
-		"message": "Static"
-	},
-	"statsForNerds": {
-		"message": "Show Stats for Nerds"
-	},
-	"step": {
-		"message": "Step"
-	},
-	"stickyNavigation": {
-		"message": "Sticky Navigation"
-	},
-	"stop": {
-		"message": "Stop"
-	},
-	"style": {
-		"message": "Style"
-	},
-	"styles": {
-		"message": "Styles"
-	},
-	"subscribe": {
-		"message": "Subscribe"
-	},
-	"subscriptions": {
-		"message": "Subscriptions"
-	},
-	"Subtitle_Capture_including_the_current_words": {
-		"message": "Subtitle (Capture including the current words)"
-	},
-	"subtitleLine": {
-		"message": "Hide subtitle red line"
-	},
-	"subtitles": {
-		"message": "Subtitles"
-	},
-	"sunset": {
-		"message": "Sunset"
-	},
-	"sunsetToSunrise": {
-		"message": "Sunset to sunrise"
-	},
-	"systemPeferenceDark": {
-		"message": "System preference: dark"
-	},
-	"systemPeferenceLight": {
-		"message": "System preference: light"
-	},
-	"teal": {
-		"message": "Teal"
-	},
-	"textColor": {
-		"message": "Text color"
-	},
-	"thanks": {
-		"message": "Thanks"
-	},
-	"themes": {
-		"message": "Themes"
-	},
-	"thisWillRemoveAllCookies": {
-		"message": "This will remove all cookies."
-	},
-	"thisWillRemoveAllWatchedVideos": {
-		"message": "This will remove all watched videos."
-	},
-	"thisWillRemoveAllYouTubeCookies": {
-		"message": "This will remove all YouTube cookies"
-	},
-	"thisWillResetAllSettings": {
-		"message": "This will reset all settings."
-	},
-	"thisWillResetAllShortcuts": {
-		"message": "This will reset all shortcuts"
-	},
-	"thumbnails": {
-		"message": "Thumbnails"
-	},
-	"thumbnailSize": {
-		"message": "Thumbnail Size"
-	},
-	"thumbnailsQuality": {
-		"message": "Thumbnails Quality"
-	},
-	"timeFrom": {
-		"message": "Time from"
-	},
-	"timeTo": {
-		"message": "Time to"
-	},
-	"To_the_side_No_page_margin": {
-		"message": "To the side! (No page margin)"
-	},
-	"todayAt": {
-		"message": "Today at"
-	},
-	"toggleAutoplay": {
-		"message": "Toggle autoplay"
-	},
-	"toggleCards": {
-		"message": "Toggle cards"
-	},
-	"toggleControls": {
-		"message": "Toggle player controls Hiding"
-	},
-	"topChat": {
-		"message": "Top chat"
-	},
-	"topLeft": {
-		"message": "Top left"
-	},
-	"topRight": {
-		"message": "Top right"
-	},
-	"trackWatchedVideos": {
-		"message": "Track watched videos"
-	},
-	"trailerAutoplay": {
-		"message": "Trailer autoplay"
-	},
-	"Transcript": {
-		"message": "Transcript"
-	},
-	"translations": {
-		"message": "Translations"
-	},
-	"transparentBackground": {
-		"message": "Transparent background"
-	},
-	"transparentBackgroundAlternative": {
-		"message": "Transparent background alternative"
-	},
-	"transparentColor": {
-		"message": "Transparent"
-	},
-	"trending": {
-		"message": "Trending"
-	},
-	"tryToReloadThePage": {
-		"message": "Try to reload the page"
-	},
-	"type": {
-		"message": "Type"
-	},
-	"undoTheNewSidebar": {
-		"message": "Undo the new sidebar!"
-	},
-	"upNextAutoplay": {
-		"message": "Up next autoplay"
-	},
-	"use24HourFormat": {
-		"message": "Use 24-hour format"
-	},
-	"version": {
-		"message": "Version"
-	},
-	"video": {
-		"message": "Video"
-	},
-	"videoDescriptionWillBeExpandedToGetNameOfCategory": {
-		"message": "The video description will be expanded to get the name of the category"
-	},
-	"videoFormats": {
-		"message": "Video formats"
-	},
-	"videos": {
-		"message": "Videos"
-	},
-	"viewMode": {
-		"message": "View Mode"
-	},
-	"volume": {
-		"message": "Volume"
-	},
-	"watchedVideos": {
-		"message": "Watched videos"
-	},
-	"watchLater": {
-		"message": "Watch later"
-	},
-	"watchTime": {
-		"message": "Watch time"
-	},
-	"whenBatteryIslowDecreaseQuality": {
-		"message": "Low battery: Decrease the quality"
-	},
-	"whenPaused": {
-		"message": "When paused"
-	},
-	"whenTabIsChanged": {
-		"message": "When tab is changed"
-	},
-	"white": {
-		"message": "White"
-	},
-	"windowColor": {
-		"message": "Window color"
-	},
-	"windowOpacity": {
-		"message": "Window opacity"
-	},
-	"with_scrollbars": {
-		"message": "with scrollbars?"
-	},
-	"withoutVideos": {
-		"message": "'Empty', without video previews"
-	},
-	"yellow": {
-		"message": "Yellow"
-	},
-	"Youtube_Search": {
-		"message": "Youtube-Search"
-	},
-	"youTubeButtons": {
-		"message": "YouTube buttons"
-	},
-	"youtubeHeaderLeft": {
-		"message": "YouTube Header (left)"
-	},
-	"youtubeHeaderRight": {
-		"message": "YouTube Header (right)"
-	},
-	"youtubeHomePage": {
-		"message": "YouTube home page"
-	},
-	"youtubeLanguage": {
-		"message": "YouTube language"
-	},
-	"youtubeLimitsVideoQualityTo1080pForH264Codec": {
-		"message": "YouTube limits video quality to 1080p for h.264 codec"
-	},
-	"youtubesDark": {
-		"message": "YouTube's Dark"
-	},
-	"youtubesLight": {
-		"message": "YouTube's Light"
-	},
-	"smartSpeedEngine": {
-		"message": "Smart Speed Engine"
-	},
-	"smartSpeedEnable": {
-		"message": "Enable Smart Speed"
-	},
-	"smartSpeedIndicator": {
-		"message": "Show On-Screen Indicator"
-	},
-	"smartSpeedMin": {
-		"message": "Min Speed (Peaks)"
-	},
-	"smartSpeedMax": {
-		"message": "Max Speed (Troughs)"
-	},
-	"smartSpeedSensitivity": {
-		"message": "Sensitivity"
-	},
-	"smartSpeedTargetToggle": {
-		"message": "Enable Target Duration"
-	},
-	"smartSpeedTargetMinutes": {
-		"message": "Target Length (Minutes)"
-	},
-	"smartSpeedProfiles": {
-		"message": "Category & Channel Profiles"
-	},
-	"smartSpeedAddProfile": {
-		"message": "Add Channel Profile"
-	},
-	"smartSpeedWhitelisted": {
-		"message": "Channel Whitelisted for Smart Speed!"
-	}
+  "hideSuggestedAction": {
+    "message": "Hide Suggested Action 'View products'"
+  },
+  "hideMerchShelf": {
+    "message": "Hide 'Merch Shelf'"
+  },
+  "about": {
+    "message": "About"
+  },
+  "accept": {
+    "message": "Accept"
+  },
+  "activate": {
+    "message": "Activate"
+  },
+  "activateCaptions": {
+    "message": "Activate captions"
+  },
+  "activated": {
+    "message": "Activated"
+  },
+  "activatedFeatures": {
+    "message": "Activated features"
+  },
+  "activateFitToWindow": {
+    "message": "Fit to window"
+  },
+  "activateFullscreen": {
+    "message": "Fullscreen"
+  },
+  "activeFeatures": {
+    "message": "My active features"
+  },
+  "addScrollToTop": {
+    "message": "Add «Scroll to top»"
+  },
+  "ads": {
+    "message": "Video Ads"
+  },
+  "all": {
+    "message": "All"
+  },
+  "allow": {
+    "message": "Allow"
+  },
+  "Allow_auto_generate": {
+    "message": "Allow auto generation"
+  },
+  "allow60fps": {
+    "message": "Allow 60fps"
+  },
+  "allYourSettingsWillBeErasedAndCanTBeRecovered": {
+    "message": "All your settings will be erased and can't be recovered"
+  },
+  "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
+    "message": "All your shortcuts will be erased and can't be recovered"
+  },
+  "always": {
+    "message": "Always"
+  },
+  "alwaysActive": {
+    "message": "Always active"
+  },
+  "alwaysShowProgressBar": {
+    "message": "Always show Progress Bar"
+  },
+  "amber": {
+    "message": "Amber"
+  },
+  "ambientLighting": {
+    "message": "Ambient lighting"
+  },
+  "analytics": {
+    "message": "Analytics"
+  },
+  "analyzer": {
+    "message": "Analyzer"
+  },
+  "animations": {
+    "message": "Animations"
+  },
+  "appearance": {
+    "message": "Appearance"
+  },
+  "areYouSureYouWantToExportTheData": {
+    "message": "Are you sure you want to export the data?"
+  },
+  "areYouSureYouWantToImportTheData": {
+    "message": "Are you sure you want to import this data?"
+  },
+  "areYouSureYouWantToSyncTheData": {
+    "message": "Are you sure you want to sync the current settings?"
+  },
+  "ARROWDOWN": {
+    "message": "⇩"
+  },
+  "ARROWLEFT": {
+    "message": "⇦"
+  },
+  "ARROWRIGHT": {
+    "message": "⇨"
+  },
+  "ARROWUP": {
+    "message": "⇧"
+  },
+  "ask": {
+    "message": "Ask"
+  },
+  "atHistory": {
+    "message": "at 'History'"
+  },
+  "atSubscriptions": {
+    "message": "at 'Subscriptions'"
+  },
+  "atTrending": {
+    "message": "at 'Trending'"
+  },
+  "audio": {
+    "message": "Audio"
+  },
+  "audioFormats": {
+    "message": "Audio formats"
+  },
+  "auto": {
+    "message": "Auto"
+  },
+  "Auto_PiP_picture_in_picture": {
+    "message": "Auto-PiP (Picture in Picture)"
+  },
+  "autoFullscreen": {
+    "message": "Auto-fullscreen"
+  },
+  "autopauseWhenSwitchingTabs": {
+    "message": "Auto-pause while I'm not in the tab"
+  },
+  "autoPictureInPicture": {
+    "message": "Auto Picture-In-Picture"
+  },
+  "autoplay": {
+    "message": "Autoplay"
+  },
+  "autoplayDisable": {
+    "message": "Force Autoplay Off"
+  },
+  "autoPlayNextShort": {
+    "message": "Shorts up next autoplay"
+  },
+  "avoidAv1": {
+    "message": "Avoid AV1"
+  },
+  "avoidAv1Vp8Vp9": {
+    "message": "Avoid AV1, VP8, VP9"
+  },
+  "avoidAv1Vp9": {
+    "message": "Avoid AV1, VP9"
+  },
+  "avoidCpuRenderingWhenPossible": {
+    "message": "Avoid CPU rendering when possible"
+  },
+  "backgroundColor": {
+    "message": "Background Color"
+  },
+  "backgroundOpacity": {
+    "message": "Background Opacity"
+  },
+  "backupAndReset": {
+    "message": "Backup & Reset"
+  },
+  "baseOnSystemColorScheme": {
+    "message": "Base on System Color Scheme"
+  },
+  "belowPlayer": {
+    "message": "Below Player"
+  },
+  "bitness": {
+    "message": "Bitness"
+  },
+  "black": {
+    "message": "Black"
+  },
+  "block_Codec_Alert_h264": {
+    "message": "You need either H.264 or VP9 enabled for Youtube to play videos."
+  },
+  "block_Codec_Alert_VP9": {
+    "message": "You need either VP9 or H.264 enabled for Youtube to play videos."
+  },
+  "blockAll": {
+    "message": "Off (block or skip)"
+  },
+  "blockAv1": {
+    "message": "Block AV1"
+  },
+  "blockH264": {
+    "message": "Block H.264"
+  },
+  "blocklist": {
+    "message": "Blocklist"
+  },
+  "blockMusic": {
+    "message": "Skip Ads while I play music"
+  },
+  "blockVp8": {
+    "message": "Block VP8"
+  },
+  "blockVp9": {
+    "message": "Block VP9"
+  },
+  "blue": {
+    "message": "Blue"
+  },
+  "blueGray": {
+    "message": "Blue gray"
+  },
+  "bluelight": {
+    "message": "Bluelight"
+  },
+  "bottomLeft": {
+    "message": "Bottom left"
+  },
+  "bottomRight": {
+    "message": "Bottom right"
+  },
+  "brightness": {
+    "message": "Brightness"
+  },
+  "brown": {
+    "message": "Brown"
+  },
+  "browser": {
+    "message": "Browser"
+  },
+  "browserAccountSync": {
+    "message": "Sync (Browser Account)"
+  },
+  "browserVersion": {
+    "message": "Browser Version"
+  },
+  "bubbles": {
+    "message": "Bubbles"
+  },
+  "bug": {
+    "message": "Bug"
+  },
+  "bulkDeleteByProgress": {
+    "message": "Bulk delete videos by watch progress"
+  },
+  "buttons": {
+    "message": "Buttons"
+  },
+  "cancel": {
+    "message": "Cancel"
+  },
+  "categories": {
+    "message": "Categories"
+  },
+  "categoryRefreshButton": {
+    "message": "Add category refresh button"
+  },
+  "changeThumbnailsPerRow": {
+    "message": "Thumbnails per Row"
+  },
+  "channel": {
+    "message": "Channel"
+  },
+  "channels": {
+    "message": "Channels"
+  },
+  "chapters": {
+    "message": "Chapters"
+  },
+  "chapterTitle": {
+    "message": "Chapter Title"
+  },
+  "characterEdgeStyle": {
+    "message": "Character Edge Style"
+  },
+  "cinemaMode": {
+    "message": "Cinema Mode"
+  },
+  "clickableLinksInDescription": {
+    "message": "Right click to copy links in video descriptions"
+  },
+  "clip": {
+    "message": "Clip"
+  },
+  "clipboard": {
+    "message": "Clipboard"
+  },
+  "codecH264": {
+    "message": "Codec h.264"
+  },
+  "codecs": {
+    "message": "Codecs"
+  },
+  "collapsed": {
+    "message": "Collapsed"
+  },
+  "collapseOfSubscriptionSections": {
+    "message": "Fold subscriptions' sections (collapsed accordion)"
+  },
+  "columns": {
+    "message": "Extra sidebar column (without moving the related videos, if the window is wide enough)"
+  },
+  "comments": {
+    "message": "Comments"
+  },
+  "compact_spacing": {
+    "message": "Compact Spacing"
+  },
+  "compactTheme": {
+    "message": "Compact Theme"
+  },
+  "confirmationBeforeClosing": {
+    "message": "Confirmation before closing"
+  },
+  "cookies": {
+    "message": "Cookies"
+  },
+  "copyVideoId": {
+    "message": "📋 Copy Video ID"
+  },
+  "copyVideoUrl": {
+    "message": "Copy Video Full URL"
+  },
+  "copyTranscript": {
+    "message": "📋 Copy Transcript"
+  },
+  "FetchingTranscript": {
+    "message": "Fetching..."
+  },
+  "TranscriptError": {
+    "message": "Error"
+  },
+  "cores": {
+    "message": "Cores"
+  },
+  "cropChapterTitles": {
+    "message": "Crop Chapter Titles"
+  },
+  "Currently_requiring_a_YouTube_API_key": {
+    "message": "(Currently requiring a YouTube-API-key: )"
+  },
+  "cursorLighting": {
+    "message": "Dim Youtube's Pages, except what I mouse-over!"
+  },
+  "custom": {
+    "message": "Custom"
+  },
+  "customCss": {
+    "message": "Custom CSS"
+  },
+  "customJs": {
+    "message": "Custom JS"
+  },
+  "customMiniPlayer": {
+    "message": "Custom Mini-Player"
+  },
+  "cyan": {
+    "message": "Cyan"
+  },
+  "dark": {
+    "message": "Dark"
+  },
+  "darkTheme": {
+    "message": "Dark theme"
+  },
+  "dateAndTime": {
+    "message": "Date & time"
+  },
+  "dawn": {
+    "message": "Dawn"
+  },
+  "decreasePlaybackSpeed": {
+    "message": "Decrease Playback Speed"
+  },
+  "decreaseVolume": {
+    "message": "Decrease Volume"
+  },
+  "deepOrange": {
+    "message": "Deep Orange"
+  },
+  "deepPurple": {
+    "message": "Deep Purple"
+  },
+  "default": {
+    "message": "Default"
+  },
+  "default_CC": {
+    "message": "default"
+  },
+  "default_theme": {
+    "message": "default"
+  },
+  "defaultChannelTab": {
+    "message": "Default channel tab"
+  },
+  "defaultContentCountry": {
+    "message": "Country (virtual travel)"
+  },
+  "defaultPlaybackSpeed": {
+    "message": "Default Playback Speed"
+  },
+  "deleteWatchedVideos": {
+    "message": "Delete watched videos"
+  },
+  "deleteYoutubeCookies": {
+    "message": "Delete YouTube cookies"
+  },
+  "depressed": {
+    "message": "Depressed"
+  },
+  "description": {
+    "message": "Description"
+  },
+  "disableSidebarScroll": {
+    "message": "Disable sidebar scroll"
+  },
+  "description_ext": {
+    "message": "YouTube, tidy & smart? Supercharge YouTube! Give it strong features, filter only the videos you want & exactly the look you like"
+  },
+  "desert": {
+    "message": "Desert"
+  },
+  "details": {
+    "message": "Details"
+  },
+  "developerOptions": {
+    "message": "Developer options"
+  },
+  "device": {
+    "message": "Device"
+  },
+  "dim": {
+    "message": "Dim"
+  },
+  "disableAutoDubbing": {
+    "message": "Disable auto dubbing"
+  },
+  "disabled": {
+    "message": "Disabled"
+  },
+  "disableLikesAnimation": {
+    "message": "Disable likes animation"
+  },
+  "disableThumbnailPlayback": {
+    "message": "Disable video playback on hover"
+  },
+  "muteThumbnailPreviews": {
+    "message": "Mute thumbnail previews"
+  },
+  "dislike": {
+    "message": "Dislike"
+  },
+  "dislikingAVideoAddsItToBlocklist": {
+    "message": "Disliking a video adds it to Blocklist"
+  },
+  "displayDayOfTheWeak": {
+    "message": "Display day of the week"
+  },
+  "donate": {
+    "message": "Donate"
+  },
+  "doNotChange": {
+    "message": "Don't change"
+  },
+  "download": {
+    "message": "Download"
+  },
+  "draggable": {
+    "message": "Draggable"
+  },
+  "dropShadow": {
+    "message": "Drop shadow"
+  },
+  "durationWithSpeed": {
+    "message": "Show time remaining with reference to playback speed"
+  },
+  "email": {
+    "message": "Email"
+  },
+  "embedded_Hide_Share": {
+    "message": "Embedded Hide Share"
+  },
+  "Embedded_YouTube": {
+    "message": "Embedded YouTube"
+  },
+  "empty": {
+    "message": "Empty"
+  },
+  "enabled": {
+    "message": "Enabled"
+  },
+  "enabledForced": {
+    "message": "Enabled (forced)"
+  },
+  "enterPassword": {
+    "message": "Please enter your 4-digit code."
+  },
+  "exact": {
+    "message": "Exact date/time"
+  },
+  "excludeShortsInPlayAll": {
+    "message": "Exclude Shorts when using \"Play all\""
+  },
+  "expanded": {
+    "message": "Expanded"
+  },
+  "exportSettings": {
+    "message": "Export settings"
+  },
+  "extension": {
+    "message": "Extension"
+  },
+  "ExtraButtons": {
+    "message": "Extra buttons"
+  },
+  "extraButtonsBelowThePlayer": {
+    "message": "Extra buttons below the player"
+  },
+  "extraRightControlButtons": {
+    "message": "Extra buttons inside the player"
+  },
+  "Feature_not_yet_available": {
+    "message": "Feature not yet available"
+  },
+  "file": {
+    "message": "File"
+  },
+  "filters": {
+    "message": "Filters"
+  },
+  "fitToWindow": {
+    "message": "Old alternative ('Fit to window')"
+  },
+  "flash": {
+    "message": "Flash"
+  },
+  "font": {
+    "message": "Font"
+  },
+  "fontColor": {
+    "message": "Font color"
+  },
+  "fontFamily": {
+    "message": "Font family"
+  },
+  "fontOpacity": {
+    "message": "Font opacity"
+  },
+  "fontSize": {
+    "message": "Font size"
+  },
+  "footer": {
+    "message": "Footer"
+  },
+  "forcedPlaybackSpeed": {
+    "message": "Speed-watching: Permanent Speed"
+  },
+  "forcedPlaybackSpeedMusic": {
+    "message": "(Force playback speed even for music?)"
+  },
+  "forcedPlayVideoFromTheBeginning": {
+    "message": "Force video to play from the beginning"
+  },
+  "forcedTheaterMode": {
+    "message": "Force Theater Mode"
+  },
+  "forcedVolume": {
+    "message": "Force Volume"
+  },
+  "forceSDR": {
+    "message": "Avoid HDR, keep SDR"
+  },
+  "foundABug": {
+    "message": "Found a bug?"
+  },
+  "fullScreenQuality": {
+    "message": "Fullscreen quality"
+  },
+  "fullscreenReturn": {
+    "message": "Fullscreen return"
+  },
+  "fullWindow": {
+    "message": "Full height"
+  },
+  "general": {
+    "message": "General"
+  },
+  "geoPreference": {
+    "message": "Geo Preference"
+  },
+  "github": {
+    "message": "GitHub"
+  },
+  "googleApiKey": {
+    "message": "Google API key"
+  },
+  "goToSearchBox": {
+    "message": "Go to search box"
+  },
+  "gpu": {
+    "message": "GPU"
+  },
+  "GPUnotindatabase": {
+    "message": "GPU not in database"
+  },
+  "green": {
+    "message": "Green"
+  },
+  "grey": {
+    "message": "Grey"
+  },
+  "halfTransparent": {
+    "message": "Faint/half-transparent"
+  },
+  "Hamburger_Menu": {
+    "message": "Hamburger Menu"
+  },
+  "hardwareInformation": {
+    "message": "Hardware information"
+  },
+  "hd": {
+    "message": "HD"
+  },
+  "hdThumbnail": {
+    "message": "HD thumbnail"
+  },
+  "header": {
+    "message": "Header"
+  },
+  "hidden": {
+    "message": "Hidden"
+  },
+  "hiddenOnVideoPage": {
+    "message": "Hidden on video page"
+  },
+  "hide_author_avatars": {
+    "message": "Hide author avatars"
+  },
+  "hide_labels": {
+    "message": "Hide names"
+  },
+  "Hide_Pause_Overlay": {
+    "message": "Hide Pause Overlay"
+  },
+  "Hide_Shorts_remixing_this_video": {
+    "message": "Hide Shorts remixing this video"
+  },
+  "Hide_sidebar": {
+    "message": "Hide sidebar "
+  },
+  "Hide_the_tabs_only": {
+    "message": "Hide the tabs only"
+  },
+  "Hide_YouTube_Logo": {
+    "message": "Hide YouTube Logo"
+  },
+  "hideAISummary": {
+    "message": "Hide AI Summaries"
+  },
+  "hideAnimatedThumbnails": {
+    "message": "Hide animated thumbnails"
+  },
+  "hideAnnotations": {
+    "message": "Hide annotations"
+  },
+  "hideBannerAds": {
+    "message": "Hide Banner Ads (YouTube might deny)"
+  },
+  "hideCards": {
+    "message": "Hide cards"
+  },
+  "hideCategories": {
+    "message": "Hide categories"
+  },
+  "hideCommentsCount": {
+    "message": "Hide comments count"
+  },
+  "hideCountryCode": {
+    "message": "Hide country code"
+  },
+  "hideDate": {
+    "message": "Hide date"
+  },
+  "hideDetailButton": {
+    "message": "Buttons (below the player)"
+  },
+  "hideDetails": {
+    "message": "Hide details"
+  },
+  "hideEndscreen": {
+    "message": "Hide endscreen"
+  },
+  "hideFeaturedContent": {
+    "message": "Hide featured content"
+  },
+  "hideFooter": {
+    "message": "Hide footer"
+  },
+  "hideGradientBottom": {
+    "message": "Hide shadow around player-bar"
+  },
+  "hideHomePageShorts": {
+    "message": "Hide Shorts on the home page"
+  },
+  "hideIncludesPaidPromotion": {
+    "message": "Hide \"Includes Paid Promotion\""
+  },
+  "hideLogo": {
+    "message": "Logo: Hide!"
+  },
+  "hideMore": {
+    "message": "Hide '...'"
+  },
+  "hidePlayerControlsBar": {
+    "message": "Hide player controls bar"
+  },
+  "hidePlayerControlsBarButtons": {
+    "message": "Hide player controls buttons"
+  },
+  "hidePlayerControlsBarOptions": {
+    "message": "Hide player controls options"
+  },
+  "hidePlaylist": {
+    "message": "Hide playlist"
+  },
+  "hideProgressBarPreview": {
+    "message": "Hide progress bar preview"
+  },
+  "hideReport": {
+    "message": "Hide 'Report'"
+  },
+  "hideRightButtons": {
+    "message": "Hide right buttons"
+  },
+  "hideScrollForDetails": {
+    "message": "Hide «Scroll for details»"
+  },
+  "hideSkipOverlay": {
+    "message": "Hide 5 second skip animation"
+  },
+  "hideSponsoredVideosOnHome": {
+    "message": "Hide sponsored videos on Home page"
+  },
+  "hidePauseOverlay": {
+    "message": "Hide Pause Overlay"
+  },
+  "hideThumbnailDots": {
+    "message": "Hide '⫶' (more actions) on thumbnails"
+  },
+  "hideThumbnailIcon": {
+    "message": "Hide thumbnail icon"
+  },
+  "hideThumbnailOverlay": {
+    "message": "Hide buttons on thumbnails"
+  },
+  "hideThumbnails": {
+    "message": "Hide thumbnails"
+  },
+  "hideTopLoadingBar": {
+    "message": "Hide Top Loading Bar"
+  },
+  "hideVideoTitleFullScreen": {
+    "message": "Hide video title in fullscreen"
+  },
+  "hideViewsCount": {
+    "message": "Hide views count"
+  },
+  "hideVoiceSearchButton": {
+    "message": "Hide voice search button"
+  },
+  "hideWatchedVideos": {
+    "message": "Hide watched videos"
+  },
+  "high": {
+    "message": "High"
+  },
+  "history": {
+    "message": "History"
+  },
+  "home": {
+    "message": "Home"
+  },
+  "homeScreen": {
+    "message": "Home screen"
+  },
+  "hover": {
+    "message": "Hover"
+  },
+  "hoverOnVideoPage": {
+    "message": "Hover on video page"
+  },
+  "howLongAgoTheVideoWasUploaded": {
+    "message": "Show video's age (how long ago it was uploaded)"
+  },
+  "icons": {
+    "message": "Icons"
+  },
+  "iconsOnly": {
+    "message": "Icon only"
+  },
+  "importSettings": {
+    "message": "Import settings"
+  },
+  "ImprovedTube": {
+    "message": "ImprovedTube"
+  },
+  "improvedtubeButtons": {
+    "message": "ImprovedTube buttons"
+  },
+  "improvedtubeIconOnYoutube": {
+    "message": "ImprovedTube icon on YouTube"
+  },
+  "improvedtubeLanguage": {
+    "message": "ImprovedTube"
+  },
+  "improvedTubeSidePanel": {
+    "message": "ImprovedTube: Browser Sidepanel"
+  },
+  "improvedtubeVersion": {
+    "message": "ImprovedTube version"
+  },
+  "improveLogo": {
+    "message": "Logo: Monochrome!"
+  },
+  "increasePlaybackSpeed": {
+    "message": "Increase playback speed"
+  },
+  "increaseVolume": {
+    "message": "Increase volume"
+  },
+  "indigo": {
+    "message": "Indigo"
+  },
+  "items": {
+    "message": "Items"
+  },
+  "join": {
+    "message": "Join"
+  },
+  "keyScene": {
+    "message": "⚡Jump to the Most Replayed Scene/s"
+  },
+  "language": {
+    "message": "Language"
+  },
+  "language_closed_caption": {
+    "message": "Language Default - Closed Captions"
+  },
+  "languages": {
+    "message": "Languages"
+  },
+  "lastWatchedFormat": {
+    "message": "Time format"
+  },
+  "lastWatchedOverlayPosition": {
+    "message": "Overlay position"
+  },
+  "layerAnimationScale": {
+    "message": "Layer animation scale"
+  },
+  "layout": {
+    "message": "Layout"
+  },
+  "Left_Side_Menu": {
+    "message": "Left Side Menu"
+  },
+  "legacyYoutube": {
+    "message": "Legacy YouTube"
+  },
+  "library": {
+    "message": "Library"
+  },
+  "light": {
+    "message": "Light"
+  },
+  "lightBlue": {
+    "message": "Light blue"
+  },
+  "lightGreen": {
+    "message": "Light green"
+  },
+  "like": {
+    "message": "Like"
+  },
+  "liked": {
+    "message": "Liked"
+  },
+  "likes": {
+    "message": "Likes"
+  },
+  "lime": {
+    "message": "Lime"
+  },
+  "limitPageWidth": {
+    "message": "Limit page width"
+  },
+  "list": {
+    "message": "List"
+  },
+  "liveChat": {
+    "message": "Live chat"
+  },
+  "liveChatType": {
+    "message": "Live chat type"
+  },
+  "location": {
+    "message": "Location"
+  },
+  "loop": {
+    "message": "🔁 Loop"
+  },
+  "loudnessNormalization": {
+    "message": "Loudness normalization"
+  },
+  "low": {
+    "message": "Low"
+  },
+  "markWatchedVideos": {
+    "message": "Mark watched videos"
+  },
+  "medium": {
+    "message": "Medium"
+  },
+  "mixer": {
+    "message": "Mixer"
+  },
+  "more": {
+    "message": "More"
+  },
+  "mostViewedChannels": {
+    "message": "Most viewed channels"
+  },
+  "moveSidebarLeft": {
+    "message": "To the left!"
+  },
+  "moveThumbnailsRight": {
+    "message": "Thumbnails to the right!"
+  },
+  "My_specs": {
+    "message": "My specs"
+  },
+  "myColors": {
+    "message": "My colors"
+  },
+  "name": {
+    "message": "Name"
+  },
+  "nativeMiniPlayer": {
+    "message": "Native mini player"
+  },
+  "new": {
+    "message": "New"
+  },
+  "nextVideo": {
+    "message": "Next video"
+  },
+  "night": {
+    "message": "Night"
+  },
+  "nightMode": {
+    "message": "Night mode"
+  },
+  "noActiveFeatures": {
+    "message": "No active features"
+  },
+  "none": {
+    "message": "None"
+  },
+  "noOpenVideoTabs": {
+    "message": "No open video tabs"
+  },
+  "normal": {
+    "message": "Normal"
+  },
+  "Not_optimal": {
+    "message": "Not optimal"
+  },
+  "off": {
+    "message": "Off"
+  },
+  "ok": {
+    "message": "Ok"
+  },
+  "old": {
+    "message": "Old"
+  },
+  "onAllVideos": {
+    "message": "On"
+  },
+  "onlyActiveOnYoutube": {
+    "message": "Only active on YouTube"
+  },
+  "onlyOnePlayerInstancePlaying": {
+    "message": "Pause while I watch a 2nd video"
+  },
+  "onSmallCreators": {
+    "message": "Off, except for small channels"
+  },
+  "onSubscribedChannels": {
+    "message": "Off, except on my subscribed channels"
+  },
+  "openNewTab": {
+    "message": "Open in a new tab"
+  },
+  "openPopupPlayer": {
+    "message": "Open video/playlist in a new window"
+  },
+  "Optimal": {
+    "message": "Optimal"
+  },
+  "optimizeCodecForHardwareAcceleration": {
+    "message": "Optimize Codec for hardware acceleration"
+  },
+  "orange": {
+    "message": "Orange"
+  },
+  "os": {
+    "message": "OS"
+  },
+  "other": {
+    "message": "Other"
+  },
+  "outline": {
+    "message": "Outline"
+  },
+  "overlay": {
+    "message": "Overlay"
+  },
+  "passwordOptions": {
+    "message": "Password options"
+  },
+  "pauseWhileIAmTypingOnYouTube": {
+    "message": "Pause when I'm typing on YouTube"
+  },
+  "pauseWhileIUnplugTheCharger": {
+    "message": "Pause when I unplug the charger"
+  },
+  "permissions": {
+    "message": "Permissions"
+  },
+  "pictureInPicture": {
+    "message": "Picture-in-Picture"
+  },
+  "pink": {
+    "message": "Pink"
+  },
+  "PipRequiresUserInteraction": {
+    "message": "PiP requires recent User interaction with source page. This is Chrome Picture-in-Picture API limitations and we cant do anything to bypass it. Works best with Autoplay disabled and manual Play control or deliberately clicking somewhere on the page before switching Tabs."
+  },
+  "plain": {
+    "message": "Plain"
+  },
+  "platform": {
+    "message": "Platform"
+  },
+  "playAllButton": {
+    "message": "\"Play all\"button"
+  },
+  "playbackSpeed": {
+    "message": "Playback speed"
+  },
+  "playbackSpeedButton": {
+    "message": "Playback speed button"
+  },
+  "playbackSpeedHotkey": {
+    "message": "Playback speed hotkeys"
+  },
+  "player": {
+    "message": "Player"
+  },
+  "player_auto_cinema_mode": {
+    "message": "Auto Cinema Mode"
+  },
+  "player_auto_hide_cinema_mode_when_paused": {
+    "message": "Auto Hide Cinema Mode on Pause"
+  },
+  "player_cinema_mode_button": {
+    "message": "Cinema Mode"
+  },
+  "player_dont_speed_education": {
+    "message": "Don't speed up the (rare) category: Education"
+  },
+  "player_fit_to_win_button": {
+    "message": "Fit to window"
+  },
+  "player_playback_speed_button": {
+    "message": "Playback Speed Button"
+  },
+  "player_rewind_and_forward_buttons": {
+    "message": "Rewind/forward buttons"
+  },
+  "player_rotate_button": {
+    "message": "Rotate video"
+  },
+  "playerAutoPipOutside": {
+    "message": "Auto-PiP only outside source Tab"
+  },
+  "playerColor": {
+    "message": "Progress bar color"
+  },
+  "playerIncreaseDecreaseSpeedButtons": {
+    "message": "Increase/Decrease Speed buttons"
+  },
+  "playerPlaybackSpeedStep": {
+    "message": "Playback Speed Step"
+  },
+  "playerSize": {
+    "message": "Player size"
+  },
+  "playlist": {
+    "message": "Playlist"
+  },
+  "playlists": {
+    "message": "Playlists"
+  },
+  "playPause": {
+    "message": "Play / Pause"
+  },
+  "popupAd": {
+    "message": "Pop-up ad: Hide"
+  },
+  "popupPlayer": {
+    "message": "Popup player"
+  },
+  "popupWindowButtons": {
+    "message": "Add a popup-player-button to each thumbnail"
+  },
+  "position": {
+    "message": "Position"
+  },
+  "pressAnyKeyOrScroll": {
+    "message": "Press any key or use mouse wheel."
+  },
+  "pressAnyKeyOrUseMouseWheel": {
+    "message": "Press any key or use mouse wheel"
+  },
+  "preventShortVideoAutoloop": {
+    "message": "Prevent short videos from auto-looping"
+  },
+  "previousVideo": {
+    "message": "Previous video"
+  },
+  "primaryColor": {
+    "message": "Primary color"
+  },
+  "pullSyncSettings": {
+    "message": "Pull"
+  },
+  "purchase": {
+    "message": "Purchase"
+  },
+  "purple": {
+    "message": "Purple"
+  },
+  "pushSyncSettings": {
+    "message": "Push"
+  },
+  "quality": {
+    "message": "Quality"
+  },
+  "qualityWhenRunningOnBattery": {
+    "message": "Quality, when running on battery"
+  },
+  "qualityWithoutFocus": {
+    "message": "Quality without focus"
+  },
+  "quickDeleteShortcut": {
+    "message": "Quick delete shortcut buttons"
+  },
+  "raised": {
+    "message": "Raised"
+  },
+  "ram": {
+    "message": "RAM"
+  },
+  "rateMe": {
+    "message": "Rate me"
+  },
+  "rateUs": {
+    "message": "Rate us"
+  },
+  "red": {
+    "message": "Red"
+  },
+  "redDislikeButton": {
+    "message": "Red when disliked"
+  },
+  "refreshCategories": {
+    "message": "Refresh categories"
+  },
+  "relatedVideos": {
+    "message": "Related videos"
+  },
+  "relative": {
+    "message": "Relative (e.g. 5m ago)"
+  },
+  "remote": {
+    "message": "Play on TV"
+  },
+  "returnYoutubeDislike": {
+    "message": "Return YouTube Dislike"
+  },
+  "returnYoutubeDislikeDescription": {
+    "message": "Display video dislike counts using Return YouTube Dislike API"
+  },
+  "Remove": {
+    "message": "Remove"
+  },
+  "removeBlackBars": {
+    "message": "Remove black bars when full screen"
+  },
+  "removeContextButtons": {
+    "message": "Remove context buttons on shorts"
+  },
+  "removeIcons": {
+    "message": "Remove icons"
+  },
+  "removeMemberOnly": {
+    "message": "Remove member only videos"
+  },
+  "removeName": {
+    "message": "Remove name"
+  },
+  "removeNames": {
+    "message": "Remove names"
+  },
+  "removePlaylistParam": {
+    "message": "Skip playlist when opening videos in new tab"
+  },
+  "removePlayables": {
+    "message": "Hide playables"
+  },
+  "removeRelatedSearchResults": {
+    "message": "Remove related search results"
+  },
+  "removeShortsReelSearchResults": {
+    "message": "Remove Shorts reel from search results"
+  },
+  "removeSubscriptionsMostRelevant": {
+    "message": "Hide 'Most relevant' section on Subscriptions page"
+  },
+  "subscriptionsListLayout": {
+    "message": "List layout on Subscriptions page"
+  },
+  "RemoveSubtitlesForLyrics": {
+    "message": "Remove subtitles for lyrics"
+  },
+  "repeat": {
+    "message": "Repeat"
+  },
+  "report": {
+    "message": "Report"
+  },
+  "requirePassword": {
+    "message": "Require password to change ImprovedTube settings"
+  },
+  "reset": {
+    "message": "Reset"
+  },
+  "resetAllSettings": {
+    "message": "Reset all settings"
+  },
+  "resetAllShortcuts": {
+    "message": "Reset all shortcuts"
+  },
+  "reverse": {
+    "message": "Reverse"
+  },
+  "revertTheaterModeButtonSizes": {
+    "message": "Revert Theater Mode Button Sizes"
+  },
+  "rotate": {
+    "message": "Rotate"
+  },
+  "save": {
+    "message": "Save"
+  },
+  "saveAs": {
+    "message": "Save as"
+  },
+  "schedule": {
+    "message": "Schedule"
+  },
+  "screen": {
+    "message": "Screen"
+  },
+  "screenshot": {
+    "message": "🖼️ Screenshot"
+  },
+  "scrollBar": {
+    "message": "Scroll Bar"
+  },
+  "sd": {
+    "message": "SD"
+  },
+  "search": {
+    "message": "Search"
+  },
+  "searchBarOnly": {
+    "message": "Search bar only"
+  },
+  "secondaryColor": {
+    "message": "Secondary color"
+  },
+  "seekBackward10Seconds": {
+    "message": "Seek backward 10 seconds"
+  },
+  "seekForward10Seconds": {
+    "message": "Seek forward 10 seconds"
+  },
+  "seekNextChapter": {
+    "message": "Seek Next Chapter"
+  },
+  "seekPreviousChapter": {
+    "message": "Seek Previous Chapter"
+  },
+  "settings": {
+    "message": "Settings"
+  },
+  "settingsSuccessfullyImported": {
+    "message": "Settings successfully imported"
+  },
+  "share": {
+    "message": "Share"
+  },
+  "shortcut_chapters": {
+    "message": "Chapters (Sidebar) On/Off"
+  },
+  "shortcut_screenshot": {
+    "message": "Screenshot"
+  },
+  "shortcut_transcript": {
+    "message": "Transcript (Sidebar) On/Off"
+  },
+  "shortcuts": {
+    "message": "Shortcuts"
+  },
+  "ShortsForceTheStandardPlayer": {
+    "message": "Shorts: Force to use the standard player"
+  },
+  "shortsAlwaysShowButtons": {
+    "message": "Shorts Always Show Control Buttons"
+  },
+  "shortsAlwaysShowCaptions": {
+    "message": "Captions Button"
+  },
+  "shortsAlwaysShowFullscreen": {
+    "message": "Fullscreen Button"
+  },
+  "showCardsOnMouseHover": {
+    "message": "Show cards on mouse hover"
+  },
+  "showChannelVideosCount": {
+    "message": "Show channel videos count"
+  },
+  "showExactDate": {
+    "message": "Show Exact Date"
+  },
+  "showLastWatchedOverlay": {
+    "message": "Show 'Last watched' overlay on thumbnails"
+  },
+  "showLess": {
+    "message": "Show less"
+  },
+  "showMore": {
+    "message": "Show more"
+  },
+  "showRemainingDuration": {
+    "message": "Show video remaining duration"
+  },
+  "showVersion": {
+    "message": "Show version"
+  },
+  "shuffle": {
+    "message": "Shuffle"
+  },
+  "sidebar": {
+    "message": "Sidebar"
+  },
+  "Sidebar_simple_alternative": {
+    "message": "Sidebar (simple alternative)"
+  },
+  "smartSpeed": {
+    "message": "Speed up lesser-watched sections"
+  },
+  "softwareInformation": {
+    "message": "Software information"
+  },
+  "spacebar": {
+    "message": "Spacebar"
+  },
+  "squaredUserImages": {
+    "message": "Squared user images"
+  },
+  "static": {
+    "message": "Static"
+  },
+  "statsForNerds": {
+    "message": "Show Stats for Nerds"
+  },
+  "step": {
+    "message": "Step"
+  },
+  "stickyNavigation": {
+    "message": "Sticky Navigation"
+  },
+  "stop": {
+    "message": "Stop"
+  },
+  "style": {
+    "message": "Style"
+  },
+  "styles": {
+    "message": "Styles"
+  },
+  "subscribe": {
+    "message": "Subscribe"
+  },
+  "subscriptions": {
+    "message": "Subscriptions"
+  },
+  "Subtitle_Capture_including_the_current_words": {
+    "message": "Subtitle (Capture including the current words)"
+  },
+  "subtitleLine": {
+    "message": "Hide subtitle red line"
+  },
+  "subtitles": {
+    "message": "Subtitles"
+  },
+  "sunset": {
+    "message": "Sunset"
+  },
+  "sunsetToSunrise": {
+    "message": "Sunset to sunrise"
+  },
+  "systemPeferenceDark": {
+    "message": "System preference: dark"
+  },
+  "systemPeferenceLight": {
+    "message": "System preference: light"
+  },
+  "teal": {
+    "message": "Teal"
+  },
+  "textColor": {
+    "message": "Text color"
+  },
+  "thanks": {
+    "message": "Thanks"
+  },
+  "themes": {
+    "message": "Themes"
+  },
+  "thisWillRemoveAllCookies": {
+    "message": "This will remove all cookies."
+  },
+  "thisWillRemoveAllWatchedVideos": {
+    "message": "This will remove all watched videos."
+  },
+  "thisWillRemoveAllYouTubeCookies": {
+    "message": "This will remove all YouTube cookies"
+  },
+  "thisWillResetAllSettings": {
+    "message": "This will reset all settings."
+  },
+  "thisWillResetAllShortcuts": {
+    "message": "This will reset all shortcuts"
+  },
+  "thumbnails": {
+    "message": "Thumbnails"
+  },
+  "thumbnailSize": {
+    "message": "Thumbnail Size"
+  },
+  "thumbnailsQuality": {
+    "message": "Thumbnails Quality"
+  },
+  "timeFrom": {
+    "message": "Time from"
+  },
+  "timeTo": {
+    "message": "Time to"
+  },
+  "To_the_side_No_page_margin": {
+    "message": "To the side! (No page margin)"
+  },
+  "todayAt": {
+    "message": "Today at"
+  },
+  "toggleAutoplay": {
+    "message": "Toggle autoplay"
+  },
+  "toggleCards": {
+    "message": "Toggle cards"
+  },
+  "toggleControls": {
+    "message": "Toggle player controls Hiding"
+  },
+  "topChat": {
+    "message": "Top chat"
+  },
+  "topLeft": {
+    "message": "Top left"
+  },
+  "topRight": {
+    "message": "Top right"
+  },
+  "trackWatchedVideos": {
+    "message": "Track watched videos"
+  },
+  "trailerAutoplay": {
+    "message": "Trailer autoplay"
+  },
+  "Transcript": {
+    "message": "Transcript"
+  },
+  "translations": {
+    "message": "Translations"
+  },
+  "transparentBackground": {
+    "message": "Transparent background"
+  },
+  "transparentBackgroundAlternative": {
+    "message": "Transparent background alternative"
+  },
+  "transparentColor": {
+    "message": "Transparent"
+  },
+  "trending": {
+    "message": "Trending"
+  },
+  "tryToReloadThePage": {
+    "message": "Try to reload the page"
+  },
+  "type": {
+    "message": "Type"
+  },
+  "undoTheNewSidebar": {
+    "message": "Undo the new sidebar!"
+  },
+  "upNextAutoplay": {
+    "message": "Up next autoplay"
+  },
+  "use24HourFormat": {
+    "message": "Use 24-hour format"
+  },
+  "version": {
+    "message": "Version"
+  },
+  "video": {
+    "message": "Video"
+  },
+  "videoDescriptionWillBeExpandedToGetNameOfCategory": {
+    "message": "The video description will be expanded to get the name of the category"
+  },
+  "videoFormats": {
+    "message": "Video formats"
+  },
+  "videos": {
+    "message": "Videos"
+  },
+  "viewMode": {
+    "message": "View Mode"
+  },
+  "volume": {
+    "message": "Volume"
+  },
+  "watchedVideos": {
+    "message": "Watched videos"
+  },
+  "watchLater": {
+    "message": "Watch later"
+  },
+  "watchTime": {
+    "message": "Watch time"
+  },
+  "whenBatteryIslowDecreaseQuality": {
+    "message": "Low battery: Decrease the quality"
+  },
+  "whenPaused": {
+    "message": "When paused"
+  },
+  "whenTabIsChanged": {
+    "message": "When tab is changed"
+  },
+  "white": {
+    "message": "White"
+  },
+  "windowColor": {
+    "message": "Window color"
+  },
+  "windowOpacity": {
+    "message": "Window opacity"
+  },
+  "with_scrollbars": {
+    "message": "with scrollbars?"
+  },
+  "withoutVideos": {
+    "message": "'Empty', without video previews"
+  },
+  "yellow": {
+    "message": "Yellow"
+  },
+  "Youtube_Search": {
+    "message": "Youtube-Search"
+  },
+  "youTubeButtons": {
+    "message": "YouTube buttons"
+  },
+  "youtubeHeaderLeft": {
+    "message": "YouTube Header (left)"
+  },
+  "youtubeHeaderRight": {
+    "message": "YouTube Header (right)"
+  },
+  "youtubeHomePage": {
+    "message": "YouTube home page"
+  },
+  "youtubeLanguage": {
+    "message": "YouTube language"
+  },
+  "youtubeLimitsVideoQualityTo1080pForH264Codec": {
+    "message": "YouTube limits video quality to 1080p for h.264 codec"
+  },
+  "youtubesDark": {
+    "message": "YouTube's Dark"
+  },
+  "youtubesLight": {
+    "message": "YouTube's Light"
+  },
+  "smartSpeedEngine": {
+    "message": "Smart Speed Engine"
+  },
+  "smartSpeedEnable": {
+    "message": "Enable Smart Speed"
+  },
+  "smartSpeedIndicator": {
+    "message": "Show On-Screen Indicator"
+  },
+  "smartSpeedMin": {
+    "message": "Min Speed (Peaks)"
+  },
+  "smartSpeedMax": {
+    "message": "Max Speed (Troughs)"
+  },
+  "smartSpeedSensitivity": {
+    "message": "Sensitivity"
+  },
+  "smartSpeedTargetToggle": {
+    "message": "Enable Target Duration"
+  },
+  "smartSpeedTargetMinutes": {
+    "message": "Target Length (Minutes)"
+  },
+  "smartSpeedProfiles": {
+    "message": "Category & Channel Profiles"
+  },
+  "smartSpeedAddProfile": {
+    "message": "Add Channel Profile"
+  },
+  "smartSpeedWhitelisted": {
+    "message": "Channel Whitelisted for Smart Speed!"
+  }
 }


### PR DESCRIPTION
Follow-up to #3752 as requested by @ImprovedTube.

Adds the missing English locale entry for the `preferredDubbingLanguage` key introduced in #3752:

```json
"preferredDubbingLanguage": { "message": "Preferred dubbing language" }
```