### PR TITLE
fix: autoplay:off & playlist-autoplay:off  take effect late   &  affect eac

### DIFF
--- a/js&css/extension/background_script_settings.js
+++ b/js&css/extension/background_script_settings.js
@@ -1,0 +1,75 @@
+/**
+ * This background script component manages extension settings for autoplay
+ * and communicates them to content scripts running on YouTube tabs.
+ * It assumes an existing `chrome.storage.sync` setup for persisting settings.
+ */
+(function() {
+    let playerAutoplay = true; // Default value, will be loaded from storage
+    let playlistAutoplay = true; // Default value, will be loaded from storage
+
+    /**
+     * Loads autoplay settings from chrome.storage.sync.
+     * After loading, it broadcasts the settings to all relevant content scripts.
+     */
+    function loadSettings() {
+        chrome.storage.sync.get(['playerAutoplay', 'playlistAutoplay'], (items) => {
+            playerAutoplay = (typeof items.playerAutoplay === 'boolean') ? items.playerAutoplay : true;
+            playlistAutoplay = (typeof items.playlistAutoplay === 'boolean') ? items.playlistAutoplay : true;
+            console.log(`Background: Settings loaded - Player Autoplay: ${playerAutoplay}, Playlist Autoplay: ${playlistAutoplay}`);
+            // Broadcast initial or updated settings to all active content scripts
+            broadcastSettingsToTabs();
+        });
+    }
+
+    /**
+     * Broadcasts the current autoplay settings to content scripts in all YouTube tabs.
+     */
+    function broadcastSettingsToTabs() {
+        chrome.tabs.query({ url: "*://*.youtube.com/*" }, (tabs) => {
+            tabs.forEach((tab) => {
+                if (tab.id) { // Ensure tab.id is valid
+                    chrome.tabs.sendMessage(tab.id, {
+                        type: 'updateAutoplaySettings',
+                        playerAutoplay: playerAutoplay,
+                        playlistAutoplay: playlistAutoplay
+                    }).catch(e => {
+                        // Catch errors if content script is not injected yet or tab closed
+                        console.warn(`Background: Could not send message to tab ${tab.id}:`, e.message);
+                    });
+                }
+            });
+        });
+    }
+
+    /**
+     * Listens for messages from content scripts or other extension parts.
+     * - 'requestAutoplaySettings': Content scripts ask for current settings.
+     * - (Future: 'saveSetting'): Options page requests to save a setting.
+     */
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        if (message.type === 'requestAutoplaySettings' && sender.tab && sender.url.includes('youtube.com')) {
+            console.debug(`Background: Content script in tab ${sender.tab.id} requested settings.`);
+            sendResponse({
+                type: 'updateAutoplaySettings', // Send back in the same format
+                playerAutoplay: playerAutoplay,
+                playlistAutoplay: playlistAutoplay
+            });
+            return true; // Indicate that sendResponse will be called asynchronously
+        }
+    });
+
+    /**
+     * Listens for changes in chrome.storage.sync (e.g., from an options page).
+     * If autoplay settings change, it reloads and broadcasts them.
+     */
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace === 'sync' && (changes.playerAutoplay || changes.playlistAutoplay)) {
+            console.log('Background: Storage change detected for autoplay settings, reloading.');
+            loadSettings(); // Reload and broadcast updated settings
+        }
+    });
+
+    // Initialize settings when the background script starts
+    loadSettings();
+
+})();

--- a/js&css/extension/youtube_player_controller.js
+++ b/js&css/extension/youtube_player_controller.js
@@ -1,0 +1,170 @@
+/**
+ * This content script runs on YouTube watch pages to enforce autoplay settings.
+ * It aims to prevent videos from starting automatically if autoplay is disabled
+ * in the extension's settings, ensuring a "stopped" state with a thumbnail
+ * and play button from the start.
+ */
+
+(function() {
+    let playerAutoplaySetting = true; // Default to true, updated by background script
+    let playlistAutoplaySetting = true; // Default to true, updated by background script
+    let settingsLoaded = false;
+
+    // Listen for settings from the background script
+    chrome.runtime.onMessage.addListener((message) => {
+        if (message.type === 'updateAutoplaySettings') {
+            playerAutoplaySetting = message.playerAutoplay;
+            playlistAutoplaySetting = message.playlistAutoplay;
+            settingsLoaded = true;
+            // Re-apply settings if a player is already present or navigating
+            handlePlayer();
+        }
+    });
+
+    // Request settings from background script immediately upon script load
+    if (chrome.runtime && chrome.runtime.sendMessage) {
+        chrome.runtime.sendMessage({ type: 'requestAutoplaySettings' });
+    }
+
+    /**
+     * Determines if the current video is part of a YouTube playlist.
+     * @returns {boolean} True if a playlist ID is found in the URL.
+     */
+    function isCurrentlyInPlaylist() {
+        return window.location.search.includes('list=') || window.location.hash.includes('list=');
+    }
+
+    /**
+     * Finds the YouTube video player element and applies autoplay settings.
+     * This function should be called when settings are updated or a new video loads.
+     */
+    function handlePlayer() {
+        if (!settingsLoaded) {
+            console.debug('Autoplay controller: Settings not loaded yet, deferring player handling.');
+            return;
+        }
+
+        // Determine if autoplay should be forced OFF based on combined settings
+        // If player autoplay is off, or if playlist autoplay is off AND we are in a playlist.
+        const forceAutoplayOff = (!playerAutoplaySetting || (!playlistAutoplaySetting && isCurrentlyInPlaylist()));
+        
+        console.debug(`Autoplay controller: Player Autoplay: ${playerAutoplaySetting}, Playlist Autoplay: ${playlistAutoplaySetting}, In Playlist: ${isCurrentlyInPlaylist()}, Force Autoplay Off: ${forceAutoplayOff}`);
+
+        const playerElement = document.querySelector('#movie_player .html5-main-video') || 
+                              document.querySelector('ytd-watch-flexy video');
+        const playerIframe = document.querySelector('iframe[src*="youtube.com/embed"]');
+
+        if (playerElement) {
+            // Handles native YouTube player on watch pages
+            if (forceAutoplayOff) {
+                // Ensure the video element's autoplay attribute is false and pause immediately
+                playerElement.removeAttribute('autoplay');
+                playerElement.autoplay = false;
+                if (!playerElement.paused) {
+                    playerElement.pause();
+                    console.debug('Autoplay controller: Paused native player.');
+                }
+                // Add an event listener to re-pause if YouTube attempts to play it later
+                playerElement.removeEventListener('play', enforcePauseNativePlayer); // Remove previous to avoid duplicates
+                playerElement.addEventListener('play', enforcePauseNativePlayer);
+            } else {
+                // If autoplay is allowed, ensure it can play
+                playerElement.autoplay = true; // Explicitly allow
+                playerElement.removeEventListener('play', enforcePauseNativePlayer);
+                // No need to call play() here, let YouTube handle it if settings allow.
+            }
+        } else if (playerIframe) {
+            // Handles embedded YouTube players in iframes
+            let src = playerIframe.src;
+            let newSrc = src;
+
+            // Remove existing autoplay parameter to ensure a clean slate
+            newSrc = newSrc.replace(/([?&])autoplay=[^&]*/g, '$1');
+
+            if (forceAutoplayOff) {
+                // Add autoplay=0 if it's not already there or to override it
+                if (!newSrc.includes('autoplay=')) {
+                    newSrc += (newSrc.includes('?') ? '&' : '?') + 'autoplay=0';
+                }
+                console.debug('Autoplay controller: Set iframe autoplay=0.');
+            } else {
+                // Add autoplay=1 if autoplay is allowed
+                if (!newSrc.includes('autoplay=')) {
+                    newSrc += (newSrc.includes('?') ? '&' : '?') + 'autoplay=1';
+                }
+                console.debug('Autoplay controller: Set iframe autoplay=1.');
+            }
+
+            // Ensure enablejsapi=1 for potential future control via YouTube Player API
+            if (!newSrc.includes('enablejsapi=')) {
+                newSrc += (newSrc.includes('?') ? '&' : '?') + 'enablejsapi=1';
+            }
+            
+            // Cleanup any potential double '?' or '&' at the start if it happened
+            newSrc = newSrc.replace(/(\?|&)&/g, '$1');
+
+            if (src !== newSrc) {
+                // Only reload iframe if the src actually changed
+                playerIframe.src = newSrc;
+                console.debug('Autoplay controller: Reloaded iframe with new src.');
+            } else {
+                console.debug('Autoplay controller: Iframe src already correct.');
+            }
+        } else {
+            console.debug('Autoplay controller: No player element found.');
+        }
+    }
+
+    /**
+     * Re-pauses the native YouTube player if autoplay is supposed to be off,
+     * in case YouTube's internal logic tries to start it.
+     */
+    function enforcePauseNativePlayer() {
+        const playerElement = this; // 'this' refers to the video element
+        const forceAutoplayOff = (!playerAutoplaySetting || (!playlistAutoplaySetting && isCurrentlyInPlaylist()));
+        
+        if (forceAutoplayOff && !playerElement.paused) {
+            playerElement.pause();
+            console.debug('Autoplay controller: Re-paused native player due to unexpected play event.');
+        }
+    }
+
+    // Monitor for navigation changes within YouTube (SPA behavior)
+    // 'yt-navigate-finish' is a custom event fired by YouTube.
+    window.addEventListener('yt-navigate-finish', () => {
+        console.debug('Autoplay controller: yt-navigate-finish event detected. Re-checking player.');
+        handlePlayer();
+    });
+
+    // Initial check when the script loads
+    console.debug('Autoplay controller: Initial script load. Checking player.');
+    handlePlayer();
+
+    // Use MutationObserver to detect when the player element itself is added/removed
+    // This is crucial for dynamically loaded players or if 'yt-navigate-finish'
+    // isn't sufficient for all scenarios (e.g., embedded players).
+    const observer = new MutationObserver(mutations => {
+        let playerFound = false;
+        for (let mutation of mutations) {
+            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+                for (let node of mutation.addedNodes) {
+                    if (node.nodeType === 1 && (node.matches('#movie_player') || node.matches('ytd-watch-flexy') || node.matches('iframe[src*="youtube.com/embed"]'))) {
+                        playerFound = true;
+                        break;
+                    }
+                }
+            }
+            if (playerFound) break;
+        }
+
+        if (playerFound) {
+            console.debug('Autoplay controller: MutationObserver detected player element. Re-checking player.');
+            // A short delay helps ensure the player is fully initialized by YouTube
+            setTimeout(handlePlayer, 100); 
+        }
+    });
+
+    // Observe the body for changes, including subtree for deep changes, to catch player insertion
+    observer.observe(document.body, { childList: true, subtree: true });
+
+})();


### PR DESCRIPTION
Closes #1508

## What changed
The fix introduces a new content script and a background script component to proactively prevent YouTube videos from autoplaying based on extension settings, ensuring videos load in a paused state with a thumbnail rather than starting and then stopping.

## Files modified
- `js&css/extension/youtube_player_controller.js`
- `js&css/extension/background_script_settings.js`

---
*Draft PR — please review before merging.*