### PR TITLE
Fix revert related video thumbnail size to previous dimensions #3777

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -380,4 +380,7 @@ html[it-thumbnails-right='true'] #related yt-lockup-view-model .yt-lockup-view-m
 }
 
   
-
+/* revert related video thumbnail size */
+a.ytLockupViewModelContentImage {
+    width: 40% !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "eslint-plugin-compat": "^5.0.0"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "*",
-        "@eslint/js": "*",
+        "@eslint/eslintrc": "latest",
+        "@eslint/js": "latest",
         "eslint": "^8.57.0",
         "globals": "^13.24.0",
         "jest": "^29.7.0",


### PR DESCRIPTION
 overrides the new width on a.ytLockupViewModelContentImage to revert the thumbnail size back to its previous dimensions.