### PR TITLE
Hide sign out menu item using SVG selector

### DIFF
--- a/menu/styles/appearance.css
+++ b/menu/styles/appearance.css
@@ -184,3 +184,6 @@
 	content: 'x';
 }
 
+yt-icon svg path[d^="M19 2a2 2"] {
+    display: none !important;
+}

--- a/menu/styles/appearance.css
+++ b/menu/styles/appearance.css
@@ -183,7 +183,3 @@
 
 	content: 'x';
 }
-
-yt-icon svg path[d^="M19 2a2 2"] {
-    display: none !important;
-}


### PR DESCRIPTION
Hide the "Sign out" menu item using a CSS selector based on its icon (SVG path).
