### PR TITLE
fix: prevent thumbnail from zooming and cropping in theater mode

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -789,3 +789,14 @@ html[it-player-hide-pause-overlay='true'] .ytp-pause-overlay {
 	opacity: 0 !important;
 	visibility: hidden !important;
 }
+
+
+/*--------------------------------------------------------------
+# FIX THUMBNAIL ZOOM/CROP IN THEATER MODE
+--------------------------------------------------------------*/
+.ytp-cued-thumbnail-overlay-image {
+    background-size: contain !important;
+    -webkit-background-size: contain !important;
+    -moz-background-size: contain !important;
+    background-color: #000 !important;
+}


### PR DESCRIPTION
Description:
Fixes: #3776 
The issue where the video thumbnail zooms in and gets heavily cropped when the user switches to Theater Mode on wide screens.

Visual Proof
Before (Cropped & Zoomed):
<img width="1885" height="733" alt="Screenshot 2026-04-17 141549" src="https://github.com/user-attachments/assets/a9e2d739-be67-44b0-8d35-331f9f05311b" />


After (Contained & Letterboxed):
<img width="1883" height="731" alt="Screenshot 2026-04-17 141718" src="https://github.com/user-attachments/assets/4a6a4526-adf8-468c-a24b-8d13618c429a" />

What Changed:
Added an override to `player.css` to change the `.ytp-cued-thumbnail-overlay-image` background size from `cover` to `contain`, ensuring the thumbnail is fully visible. I also added a black background color to handle the letterboxing.