### PR TITLE
Fix #1637: Apply forced volume in iframe/embed context on first load

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -178,6 +178,10 @@ ImprovedTube.ytElementsHandler = function (node) {
 			ImprovedTube.elements.player_thumbnail = node.querySelector('.ytp-cued-thumbnail-overlay-image');
 			ImprovedTube.elements.player_subtitles_button = node.querySelector('.ytp-subtitles-button');
 			ImprovedTube.playerSize();
+			// Fix #1637: Apply forced volume in iframe/embed context when player is first detected
+			if (ImprovedTube.video_url !== location.href && ImprovedTube.elements.player.setPlaybackRate) {
+				ImprovedTube.initPlayer();
+			}
 			if (typeof this.storage.ads !== 'undefined' && this.storage.ads !== "all_videos") {
 				new MutationObserver(function (mutationList) {
 					for (var i = 0, l = mutationList.length; i < l; i++) {


### PR DESCRIPTION
## Fix #1637: Apply forced volume in iframe/embed context on first load

### Problem
When YouTube videos are embedded in iframes (e.g., on Google search results), the forced volume setting is not applied on first load or in incognito mode.

### Root Cause
`initPlayer()` is only called from `init()`. In embedded player contexts, the `yt-page-data-updated` event does not fire, so `initPlayer()` is never called after the player element is detected.

### Fix
Added `initPlayer()` call directly in `ytElementsHandler` when `movie_player` is first detected.

### Testing
- Open a YouTube video embedded in an iframe (e.g., from Google search results)
- Set forced volume to a specific value in ImprovedTube settings
- Load the page in incognito mode or with cache cleared (ctrl+f5)
- Volume should be applied immediately without requiring a refresh