### PR TITLE
feat: add option to collapse/expand transcript panel

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -329,6 +329,9 @@
   "copyTranscript": {
     "message": "📋 Copy Transcript"
   },
+  "Collapse_transcript_panel": {
+    "message": "Add collapse/expand button to transcript panel"
+  },
   "FetchingTranscript": {
     "message": "Fetching..."
   },

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -131,6 +131,20 @@ html[data-page-type=video][it-transcript='true'][it-transcript-collapsed='true']
     transform: rotate(180deg) !important;
 }
 
+#it-transcript-collapse-btn {
+    position: absolute !important;
+    top: 10px !important;
+    right: 10px !important;
+    z-index: 999 !important;
+    padding: 4px 8px !important;
+    background: var(--yt-spec-button-chip-background) !important;
+    border: 1px solid var(--yt-spec-10-percent-layer) !important;
+    border-radius: 4px !important;
+    cursor: pointer !important;
+    font-size: 12px !important;
+    color: var(--yt-spec-text-primary) !important;
+}
+
 /*--------------------------------------------------------------
 # RELATED VIDEO STYLES
 --------------------------------------------------------------*/

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -113,6 +113,25 @@ html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'] 
 }
 
 /*--------------------------------------------------------------
+# TRANSCRIPT COLLAPSED STATE
+--------------------------------------------------------------*/
+html[data-page-type=video][it-transcript='true'][it-transcript-collapsed='true'] *[target-id*='transcript'] {
+    max-width: 60px !important;
+    min-width: 60px !important;
+}
+
+html[data-page-type=video][it-transcript='true'][it-transcript-collapsed='true'] *[target-id*='transcript'] ytd-engagement-panel-section-list-renderer #content {
+    display: none !important;
+}
+
+html[data-page-type=video][it-transcript='true'][it-transcript-collapsed='true'] *[target-id*='transcript'] #title {
+    opacity: 1 !important;
+    writing-mode: vertical-rl !important;
+    text-orientation: mixed !important;
+    transform: rotate(180deg) !important;
+}
+
+/*--------------------------------------------------------------
 # RELATED VIDEO STYLES
 --------------------------------------------------------------*/
 html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) {opacity:0.8;  max-height:80px; overflow:hidden; margin-top:-1px;  transition: max-height 0.2s ease 0.15s;}

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -272,8 +272,11 @@ document.addEventListener('it-message-from-extension', function () {
 
 				case 'transcript':
 					if (ImprovedTube.storage.transcript === true) {
-						document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');
-					} else if (ImprovedTube.storage.transcript === false) {
+						document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');					// Add collapse button after transcript is opened
+					const transcriptPanel = document.querySelector('ytd-watch-flexy');
+					if (transcriptPanel) {
+						setTimeout(() => ImprovedTube.transcriptCollapseButton(transcriptPanel), 500);
+					}					} else if (ImprovedTube.storage.transcript === false) {
 						document.querySelector('*[target-id*=transcript] #visibility-button button')?.click();
 					}
 					break

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -272,11 +272,19 @@ document.addEventListener('it-message-from-extension', function () {
 
 				case 'transcript':
 					if (ImprovedTube.storage.transcript === true) {
-						document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');					// Add collapse button after transcript is opened
-					const transcriptPanel = document.querySelector('ytd-watch-flexy');
-					if (transcriptPanel) {
-						setTimeout(() => ImprovedTube.transcriptCollapseButton(transcriptPanel), 500);
-					}					} else if (ImprovedTube.storage.transcript === false) {
+						document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');
+
+						// Add collapse button after transcript is opened
+						const transcriptPanel = document.querySelector('ytd-watch-flexy');
+
+						if (transcriptPanel && typeof ImprovedTube.transcriptCollapseButton === 'function') {
+							setTimeout(() => {
+								if (typeof ImprovedTube.transcriptCollapseButton === 'function') {
+									ImprovedTube.transcriptCollapseButton(transcriptPanel);
+								}
+							}, 500);
+						}
+					} else if (ImprovedTube.storage.transcript === false) {
 						document.querySelector('*[target-id*=transcript] #visibility-button button')?.click();
 					}
 					break

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -405,6 +405,8 @@ ImprovedTube.transcriptCollapseButton = function (el) {
     // Create collapse/expand button
     const button = document.createElement('button');
     button.id = 'it-transcript-collapse-btn';
+    button.setAttribute('aria-label', 'Collapse transcript panel');
+    button.setAttribute('title', 'Collapse transcript panel');
     button.style.cssText = `
         position: absolute;
         top: 10px;
@@ -429,9 +431,13 @@ ImprovedTube.transcriptCollapseButton = function (el) {
         if (isCollapsed) {
             document.documentElement.setAttribute('it-transcript-collapsed', 'true');
             button.textContent = '+'; // expand symbol
+            button.setAttribute('aria-label', 'Expand transcript panel');
+            button.setAttribute('title', 'Expand transcript panel');
         } else {
             document.documentElement.removeAttribute('it-transcript-collapsed');
             button.textContent = '−'; // collapse symbol
+            button.setAttribute('aria-label', 'Collapse transcript panel');
+            button.setAttribute('title', 'Collapse transcript panel');
         }
     };
     

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -442,6 +442,37 @@ ImprovedTube.transcriptCollapseButton = function (el) {
         titleElement.parentElement.appendChild(button);
     }
 };
+
+/*-------------------------------------------------------------------------
+TRANSCRIPT COLLAPSE CLEANUP
+-------------------------------------------------------------------------------*/
+
+ImprovedTube.cleanupTranscriptCollapse = function () {
+    // Remove the collapse button
+    const button = document.querySelector('#it-transcript-collapse-btn');
+    if (button) {
+        button.remove();
+    }
+    
+    // Clear the collapsed attribute
+    document.documentElement.removeAttribute('it-transcript-collapsed');
+};
+
+/*-------------------------------------------------------------------------
+TRANSCRIPT COLLAPSE STORAGE LISTENER
+-------------------------------------------------------------------------------*/
+
+if (!ImprovedTube.transcriptCollapseListener) {
+    ImprovedTube.transcriptCollapseListener = true;
+    
+    document.addEventListener('it-storage-update', function (e) {
+        if (e.detail && e.detail.key === 'transcript_collapse') {
+            if (e.detail.value === false) {
+                ImprovedTube.cleanupTranscriptCollapse();
+            }
+        }
+    });
+}
 /*----------------------------------------------------------------
  CHAPTERS
 --------------------------------------------------------------*/

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -419,8 +419,8 @@ ImprovedTube.transcriptCollapseButton = function (el) {
         color: var(--yt-spec-text-primary);
     `;
     
-    let isCollapsed = false;
-    button.textContent = '−'; // collapse symbol
+    let isCollapsed = document.documentElement.hasAttribute('it-transcript-collapsed');
+    button.textContent = isCollapsed ? '+' : '−'; // expand/collapse symbol based on current state
     
     button.onclick = function(e) {
         e.stopPropagation();

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -407,19 +407,6 @@ ImprovedTube.transcriptCollapseButton = function (el) {
     button.id = 'it-transcript-collapse-btn';
     button.setAttribute('aria-label', 'Collapse transcript panel');
     button.setAttribute('title', 'Collapse transcript panel');
-    button.style.cssText = `
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        z-index: 999;
-        padding: 4px 8px;
-        background: var(--yt-spec-button-chip-background);
-        border: 1px solid var(--yt-spec-10-percent-layer);
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 12px;
-        color: var(--yt-spec-text-primary);
-    `;
     
     let isCollapsed = document.documentElement.hasAttribute('it-transcript-collapsed');
     button.textContent = isCollapsed ? '+' : '−'; // expand/collapse symbol based on current state

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -373,18 +373,75 @@ ImprovedTube.hideTopProgressBar = function () {
 ImprovedTube.transcript = function (el) { if (ImprovedTube.storage.transcript === true) {
 	const available = el.querySelector('[target-id*=transcript][visibility*=HIDDEN]') || el.querySelector('[target-id*=transcript]')?.clientHeight;
 	if (available) {
-		if (!ImprovedTube.originalFocus) {ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
+		if (!ImprovedTube.originalFocus) {ImprovedTube.originalFocus = HTMLElement.prototype.focus;}
 		ImprovedTube.forbidFocus =  function (ms) { 
 			HTMLElement.prototype.focus = function() {console.log("Preventing YouTube's scripted scrolling for a moment."); }
 			if(document.hidden) ms = 3*ms;
-			setTimeout(function() { HTMLElement.prototype.focus = ImprovedTube.originalFocus; }, ms); 	// Restoring JS's "focus()" 
+			setTimeout(function() { HTMLElement.prototype.focus = ImprovedTube.originalFocus; }, ms); 	
 		}
 		ImprovedTube.forbidFocus(2100);
 		const descriptionTranscript = el.querySelector('ytd-video-description-transcript-section-renderer button[aria-label]');
 		descriptionTranscript ? descriptionTranscript.click() : el.querySelector('[target-id*=transcript]')?.removeAttribute('visibility');
 		if ( yt.config_.EXPERIMENT_FLAGS.kevlar_watch_grid === true ) { available.setAttribute('z-index', '98765') }
+		
+		// Add collapse button after transcript is opened
+		setTimeout(() => ImprovedTube.transcriptCollapseButton(el), 500);
 	}  
 }};
+
+/*-------------------------------------------------------------------------
+TRANSCRIPT COLLAPSE BUTTON
+-------------------------------------------------------------------------------*/
+
+ImprovedTube.transcriptCollapseButton = function (el) {
+    if (ImprovedTube.storage.transcript_collapse !== true) return;
+    
+    const transcriptPanel = el?.querySelector('[target-id*=transcript]');
+    if (!transcriptPanel) return;
+    
+    // Check if button already exists
+    if (transcriptPanel.querySelector('#it-transcript-collapse-btn')) return;
+    
+    // Create collapse/expand button
+    const button = document.createElement('button');
+    button.id = 'it-transcript-collapse-btn';
+    button.style.cssText = `
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 999;
+        padding: 4px 8px;
+        background: var(--yt-spec-button-chip-background);
+        border: 1px solid var(--yt-spec-10-percent-layer);
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+        color: var(--yt-spec-text-primary);
+    `;
+    
+    let isCollapsed = false;
+    button.textContent = '−'; // collapse symbol
+    
+    button.onclick = function(e) {
+        e.stopPropagation();
+        isCollapsed = !isCollapsed;
+        
+        if (isCollapsed) {
+            document.documentElement.setAttribute('it-transcript-collapsed', 'true');
+            button.textContent = '+'; // expand symbol
+        } else {
+            document.documentElement.removeAttribute('it-transcript-collapsed');
+            button.textContent = '−'; // collapse symbol
+        }
+    };
+    
+    // Insert button into the title area
+    const titleElement = transcriptPanel.querySelector('#title');
+    if (titleElement) {
+        titleElement.parentElement.style.position = 'relative';
+        titleElement.parentElement.appendChild(button);
+    }
+};
 /*----------------------------------------------------------------
  CHAPTERS
 --------------------------------------------------------------*/

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -438,8 +438,17 @@ ImprovedTube.transcriptCollapseButton = function (el) {
     // Insert button into the title area
     const titleElement = transcriptPanel.querySelector('#title');
     if (titleElement) {
-        titleElement.parentElement.style.position = 'relative';
-        titleElement.parentElement.appendChild(button);
+        const titleParent = titleElement.parentElement;
+        if (titleParent) {
+            const inlinePosition = titleParent.style.position;
+            const computedPosition = window.getComputedStyle(titleParent).position;
+
+            if (!inlinePosition && computedPosition === 'static') {
+                titleParent.style.position = 'relative';
+            }
+
+            titleParent.appendChild(button);
+        }
     }
 };
 /*----------------------------------------------------------------

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -1075,6 +1075,13 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 					}
 				}
 			},
+			transcript_collapse: {
+				component: 'switch',
+				text: 'Collapse_transcript_panel',
+				value: true,
+				id: 'transcript-collapse',
+				tags: 'transcript,collapse'
+			},
 			compact_spacing: {
 				component: "switch",
 				text: 'compact_spacing',

--- a/tests/unit/transcript-collapse.test.js
+++ b/tests/unit/transcript-collapse.test.js
@@ -1,0 +1,144 @@
+// Test for transcript collapse/expand button functionality
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Transcript Collapse Button Feature', () => {
+	describe('appearance.js - transcriptCollapseButton', () => {
+		let appearanceContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/appearance.js');
+			appearanceContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should create button with correct ID', () => {
+			expect(appearanceContent).toContain("button.id = 'it-transcript-collapse-btn'");
+		});
+
+		test('should have accessibility attributes', () => {
+			expect(appearanceContent).toContain("button.setAttribute('aria-label'");
+			expect(appearanceContent).toContain("button.setAttribute('title'");
+		});
+
+		test('should toggle collapsed attribute on button click', () => {
+			expect(appearanceContent).toContain("document.documentElement.setAttribute('it-transcript-collapsed', 'true')");
+			expect(appearanceContent).toContain("document.documentElement.removeAttribute('it-transcript-collapsed')");
+		});
+
+		test('should update aria-label based on collapsed state', () => {
+			expect(appearanceContent).toContain("'Collapse transcript panel'");
+			expect(appearanceContent).toContain("'Expand transcript panel'");
+		});
+
+		test('should check if feature is enabled before creating button', () => {
+			expect(appearanceContent).toContain("if (ImprovedTube.storage.transcript_collapse !== true) return;");
+		});
+	});
+
+	describe('appearance.js - cleanupTranscriptCollapse', () => {
+		let appearanceContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/appearance.js');
+			appearanceContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should have cleanup function defined', () => {
+			expect(appearanceContent).toContain("ImprovedTube.cleanupTranscriptCollapse = function");
+		});
+
+		test('should remove button from DOM', () => {
+			expect(appearanceContent).toContain("document.querySelector('#it-transcript-collapse-btn')");
+			expect(appearanceContent).toContain(".remove()");
+		});
+
+		test('should clear collapsed attribute', () => {
+			expect(appearanceContent).toContain("document.documentElement.removeAttribute('it-transcript-collapsed')");
+		});
+	});
+
+	describe('appearance.js - storage event listener', () => {
+		let appearanceContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/appearance.js');
+			appearanceContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should listen to storage update events', () => {
+			expect(appearanceContent).toContain("document.addEventListener('it-storage-update'");
+		});
+
+		test('should monitor transcript_collapse setting changes', () => {
+			expect(appearanceContent).toContain("e.detail.key === 'transcript_collapse'");
+		});
+
+		test('should call cleanup when setting is disabled', () => {
+			expect(appearanceContent).toContain("if (e.detail.value === false)");
+			expect(appearanceContent).toContain("ImprovedTube.cleanupTranscriptCollapse()");
+		});
+	});
+
+	describe('sidebar.css - button styling', () => {
+		let sidebarContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css');
+			sidebarContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should have button styling in CSS', () => {
+			expect(sidebarContent).toContain("#it-transcript-collapse-btn");
+		});
+
+		test('should position button absolutely', () => {
+			expect(sidebarContent).toContain("position: absolute");
+		});
+
+		test('should style collapsed state properly', () => {
+			expect(sidebarContent).toContain("it-transcript-collapsed");
+			expect(sidebarContent).toContain("max-width: 60px");
+		});
+	});
+
+	describe('menu settings configuration', () => {
+		let menuContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../menu/skeleton-parts/appearance.js');
+			menuContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should have transcript_collapse toggle in menu', () => {
+			expect(menuContent).toContain("transcript_collapse:");
+			expect(menuContent).toContain("component: 'switch'");
+		});
+
+		test('should have correct label reference', () => {
+			expect(menuContent).toContain("text: 'Collapse_transcript_panel'");
+		});
+
+		test('should set default value to true', () => {
+			expect(menuContent).toContain("value: true");
+		});
+	});
+
+	describe('translations', () => {
+		let messagesContent;
+
+		beforeAll(() => {
+			const filePath = path.join(__dirname, '../../_locales/en/messages.json');
+			messagesContent = fs.readFileSync(filePath, 'utf8');
+		});
+
+		test('should have message for Collapse_transcript_panel', () => {
+			expect(messagesContent).toContain("Collapse_transcript_panel");
+		});
+
+		test('should have descriptive message', () => {
+			expect(messagesContent).toContain("collapse");
+			expect(messagesContent).toContain("expand");
+		});
+	});
+});


### PR DESCRIPTION
## Add collapse/expand button to transcript panel

### Description
This PR adds an optional collapse/expand button to the YouTube transcript panel, allowing users to save screen space while watching videos.

### Changes
- Added collapse/expand toggle button (−/+) to transcript panel header
- New `transcript_collapse` setting in Appearance → Sidebar menu
- When collapsed, transcript panel shrinks to 60px width with vertical title text
- Added localization string for the feature

### Files Modified
- `_locales/en/messages.json` - Added localization string
- `js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css` - Styling for collapsed state
- `js&css/web-accessible/core.js` - Initialize collapse button when transcript opens
- `js&css/web-accessible/www.youtube.com/appearance.js` - Button creation and toggle logic
- `menu/skeleton-parts/appearance.js` - Settings menu entry

### Testing
- Verify button appears when transcript feature is enabled
- Test collapse/expand toggle functionality
- Confirm styling works across different video pages
- Validate transcript content is accessible when expanded