### PR TITLE
Add option to collapse the Transcript panel

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,7 +1,7 @@
 {
   "preferredDubbingLanguage": {
-		"message": "Preferred dubbing language"
-	},
+    "message": "Preferred dubbing language"
+  },
   "hideSuggestedAction": {
     "message": "Hide Suggested Action 'View products'"
   },
@@ -1519,6 +1519,9 @@
   },
   "Transcript": {
     "message": "Transcript"
+  },
+  "transcriptCollapse": {
+    "message": "Collapse Transcript"
   },
   "translations": {
     "message": "Translations"

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -24,7 +24,7 @@ html[it-hide-sidebar='true'] ytd-watch-flexy[flexy] #primary.ytd-watch-flexy {
 	min-width: unset !important;
 }
 
-html[it-hide-sidebar='true'] ytd-watch-flexy[flexy] #secondary{
+html[it-hide-sidebar='true'] ytd-watch-flexy[flexy] #secondary {
 	container-name: sidebar;
 	container-type: inline-size;
 }
@@ -37,56 +37,64 @@ div#secondary #playlist {
 	max-width: var(--ytd-watch-flexy-sidebar-width);
 	min-width: unset !important;
 }
+
 /*--------------------------------------------------------------
 # TRANSCRIPT
 --------------------------------------------------------------*/
-html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'], 
-html[data-page-type=video][it-transcript='true'] *[target-id*='transcript']  ytd-engagement-panel-section-list-renderer #content {
+html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'],
+html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'] ytd-engagement-panel-section-list-renderer #content {
 	max-height: 77vh !important;
 }
+
 html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'] #title {
 	opacity: 0.4;
 }
 
-html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']  ytd-watch-flexy:not([fullscreen]) #columns {
-	display:flex !important;
-	max-width:99% !important;
-} 
-html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'], 
+html[data-page-type=video][it-transcript='true'][it-sidebar-left='true'] ytd-watch-flexy:not([fullscreen]) #columns {
+	display: flex !important;
+	max-width: 99% !important;
+}
+
+html[data-page-type=video][it-transcript='true'] *[target-id*='transcript'],
 html[data-page-type=video][it-transcript='true'] *[target-id*='transcript']:not([it-sidebar-left='true']) ytd-engagement-panel-section-list-renderer #content {
-	min-width: max(445px,17vw) !important;
-	max-width: min(24vw,650px) !important;
+	min-width: max(445px, 17vw) !important;
+	max-width: min(24vw, 650px) !important;
 	margin-left: -20px !important;
-} 
+}
+
 html[data-page-type=video][it-transcript='true']:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #player {
 	max-width: 1280px !important;
 }
 
-@media screen and  (min-width: 1599px) {	
-html[data-page-type=video][it-transcript='true']  ytd-watch-flexy:not([fullscreen]) #secondary {
-	display:flex !important;
- max-width: 99% !important;
-} 
-html[data-page-type=video][it-transcript='true'] ytd-browse > ytd-two-column-browse-results-renderer {
-	object-fit: contain !important;
-	max-width: 99% !important;
-	margin: -5px;
-}
-html[data-page-type=video][it-transcript='true'][it-sidebar-left='true'] *[target-id*='transcript'],
-html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']:not([it-player-size='max_width']) *[target-id*='transcript'] {
-	min-width: 440px !important;
-	max-width:440px !important;
-	object-fit: contain !important;
-	overflow-x: hidden !important;
-	float: right;  /* direction: rtl; */
-}
-/*
+@media screen and (min-width: 1599px) {
+	html[data-page-type=video][it-transcript='true'] ytd-watch-flexy:not([fullscreen]) #secondary {
+		display: flex !important;
+		max-width: 99% !important;
+	}
+
+	html[data-page-type=video][it-transcript='true'] ytd-browse>ytd-two-column-browse-results-renderer {
+		object-fit: contain !important;
+		max-width: 99% !important;
+		margin: -5px;
+	}
+
+	html[data-page-type=video][it-transcript='true'][it-sidebar-left='true'] *[target-id*='transcript'],
+	html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']:not([it-player-size='max_width']) *[target-id*='transcript'] {
+		min-width: 440px !important;
+		max-width: 440px !important;
+		object-fit: contain !important;
+		overflow-x: hidden !important;
+		float: right;
+		/* direction: rtl; */
+	}
+
+	/*
 html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']:not([it-player-size='max_width']) td-engagement-panel-section-list-renderer {
 	text-align: right !important;
 	direction: ltr;
 }
 */
-/* caused #cinematics to get a higher z-index:
+	/* caused #cinematics to get a higher z-index:
 html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']:not([it-player-size='max_width']) #player {
 	z-index:1000 !important;
 	left:-10px !important;
@@ -94,41 +102,144 @@ html[data-page-type=video][it-transcript='true'][it-sidebar-left='true']:not([it
 */
 }
 
-html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer:hover { overflow-x: visible !important; }
-html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer:has(+ ytd-transcript-segment-renderer.active) yt-formatted-string 
-{margin-bottom:-5px !important; margin-top:-5px !important; font-size:1.26em !important;} 
-html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active yt-formatted-string 
-{margin-bottom:-5px !important; margin-top:-5px !important; font-size:1.35em !important;}		
-html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active + ytd-transcript-segment-renderer yt-formatted-string 
-{margin-bottom:-5px !important; margin-top:-5px !important; font-size:1.30em !important;}
-html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active + ytd-transcript-segment-renderer + ytd-transcript-segment-renderer yt-formatted-string 
-{margin-bottom:-5px !important; margin-top:-5px !important; font-size:1.24em !important;}
-html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'] ytd-transcript-segment-renderer *
-{margin-bottom:-4px !important; margin-top:-4px !important; }
-
-html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'], 
-html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript']  ytd-engagement-panel-section-list-renderer #content {
-	max-height: 69vh !important;
-	margin-top:40px !important;
+html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer:hover {
+	overflow-x: visible !important;
 }
+
+html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer:has(+ ytd-transcript-segment-renderer.active) yt-formatted-string {
+	margin-bottom: -5px !important;
+	margin-top: -5px !important;
+	font-size: 1.26em !important;
+}
+
+html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active yt-formatted-string {
+	margin-bottom: -5px !important;
+	margin-top: -5px !important;
+	font-size: 1.35em !important;
+}
+
+html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active+ytd-transcript-segment-renderer yt-formatted-string {
+	margin-bottom: -5px !important;
+	margin-top: -5px !important;
+	font-size: 1.30em !important;
+}
+
+html[data-page-type=video][it-transcript='true'] ytd-transcript-segment-renderer.active+ytd-transcript-segment-renderer+ytd-transcript-segment-renderer yt-formatted-string {
+	margin-bottom: -5px !important;
+	margin-top: -5px !important;
+	font-size: 1.24em !important;
+}
+
+html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'] ytd-transcript-segment-renderer * {
+	margin-bottom: -4px !important;
+	margin-top: -4px !important;
+}
+
+html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'],
+html[data-page-type=video][it-compactSpacing='true'] *[target-id*='transcript'] ytd-engagement-panel-section-list-renderer #content {
+	max-height: 69vh !important;
+	margin-top: 40px !important;
+}
+
+/*--------------------------------------------------------------
+# TRANSCRIPT COLLAPSE
+--------------------------------------------------------------*/
+html[it-transcript-collapse='true'] ytd-engagement-panel-section-list-renderer[target-id*='transcript'] #header {
+	cursor: pointer !important;
+}
+
+html[it-transcript-collapse='true'] ytd-engagement-panel-section-list-renderer[target-id*='transcript']:not([it-activated]) #content {
+	display: none !important;
+}
+
+html[it-transcript-collapse='true'] ytd-engagement-panel-section-list-renderer[target-id*='transcript']:not([it-activated]) {
+	min-height: unset !important;
+}
+
 
 /*--------------------------------------------------------------
 # RELATED VIDEO STYLES
 --------------------------------------------------------------*/
-html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) {opacity:0.8;  max-height:80px; overflow:hidden; margin-top:-1px;  transition: max-height 0.2s ease 0.15s;}
-html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-thumbnail {transform:scale(0.8); transform-origin: top; transition: all 0.2s ease 0.15s;}
-html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {transform:scale(0.8); transform-origin: top; transition: all 0.2s ease 0.15s;}
-html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) {opacity: 1;  max-height: 100px; transition: max-height 0.3s ease 0.1s; margin-left: 0px !important}
-html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-thumbnail {max-width: 170px; transform:scale(1); transition: all 0.3s ease 0.1s;}
-html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {max-width: 170px; transform:scale(1); transition: all 0.3s ease 0.1s;}
+html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) {
+	opacity: 0.8;
+	max-height: 80px;
+	overflow: hidden;
+	margin-top: -1px;
+	transition: max-height 0.2s ease 0.15s;
+}
 
-html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) {opacity:0.8;  max-height:40px; overflow:hidden; margin-top:-1px;  transition: max-height 0.3s ease 0.1s;}
-html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) ytd-thumbnail {max-width: 0px; transition: max-width 0.4s ease 0.1s;}
-html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {max-width: 0px; transition: max-width 0.4s ease 0.1s;}
-html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) {opacity: 1;  max-height: 100px; transition: max-height 0.3s ease 0.9s; margin-left: 0px !important}
-html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) ytd-thumbnail {max-width: 170px; transform:scale(1); transition: max-width 0.3s ease 0.9s;}
-html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {max-width: 170px; transform:scale(1); transition: max-width 0.3s ease 0.9s;}
-html[it-related-videos='Titles'] #related #dismissible #metadata {margin-top:-3px;}
+html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-thumbnail {
+	transform: scale(0.8);
+	transform-origin: top;
+	transition: all 0.2s ease 0.15s;
+}
+
+html[it-related-videos='Focus'] #related #dismissible:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {
+	transform: scale(0.8);
+	transform-origin: top;
+	transition: all 0.2s ease 0.15s;
+}
+
+html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) {
+	opacity: 1;
+	max-height: 100px;
+	transition: max-height 0.3s ease 0.1s;
+	margin-left: 0px !important
+}
+
+html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-thumbnail {
+	max-width: 170px;
+	transform: scale(1);
+	transition: all 0.3s ease 0.1s;
+}
+
+html[it-related-videos='Focus'] #related #dismissible:hover:not(.it-blocklisted-video):not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {
+	max-width: 170px;
+	transform: scale(1);
+	transition: all 0.3s ease 0.1s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) {
+	opacity: 0.8;
+	max-height: 40px;
+	overflow: hidden;
+	margin-top: -1px;
+	transition: max-height 0.3s ease 0.1s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) ytd-thumbnail {
+	max-width: 0px;
+	transition: max-width 0.4s ease 0.1s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible:not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {
+	max-width: 0px;
+	transition: max-width 0.4s ease 0.1s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) {
+	opacity: 1;
+	max-height: 100px;
+	transition: max-height 0.3s ease 0.9s;
+	margin-left: 0px !important
+}
+
+html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) ytd-thumbnail {
+	max-width: 170px;
+	transform: scale(1);
+	transition: max-width 0.3s ease 0.9s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible:hover:not(.ytd-reel-item-renderer) ytd-playlist-thumbnail {
+	max-width: 170px;
+	transform: scale(1);
+	transition: max-width 0.3s ease 0.9s;
+}
+
+html[it-related-videos='Titles'] #related #dismissible #metadata {
+	margin-top: -3px;
+}
+
 /* timestamps..? html[it-related-videos='Titles'] #overlays {margin-right:100px; margin-bottom:50px; opacity: 1 !important; visiblity: visible !important;} */
 /* html[it-related-videos='Titles'] #related #dismissible #metadata * {display: inline-block !important}
 */
@@ -142,13 +253,15 @@ html[it-hide-shorts-remixing='true'] #related ytd-reel-shelf-renderer,
 --------------------------------------------------------------*/
 html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer ytd-thumbnail,
 html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer ytd-playlist-thumbnail,
-/*update Aug 22th 2025 by @JadonDn:*/ html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer .yt-lockup-view-model-wiz__content-image,
+/*update Aug 22th 2025 by @JadonDn:*/
+html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer .yt-lockup-view-model-wiz__content-image,
 /*--------------------------------------------------------------
 # LIVECHAT
 --------------------------------------------------------------*/
 html[it-livechat='hidden'] ytd-live-chat-frame#chat {
-	  display: none !important;
+	display: none !important;
 }
+
 html[it-livechat='collapsed'] #chat-container:not([it-activated])::before {
 	content: 'Show live chat' !important;
 }
@@ -175,16 +288,15 @@ html[it-livechat='collapsed'] #chat-container::before {
 	align-items: center !important;
 }
 
-html[it-livechat='collapsed'] #chat-container:not([it-activated]) > ytd-live-chat-frame#chat {
+html[it-livechat='collapsed'] #chat-container:not([it-activated])>ytd-live-chat-frame#chat {
 	display: none !important;
 }
 
 html[it-livechat='collapsed'][it-livechat='hidden'] ytd-live-chat-frame#chat {
-  display: none !important;
+	display: none !important;
 }
 
-html[it-livechat='collapsed'] 
-#chat-container:not([it-activated])::before, 
+html[it-livechat='collapsed'] #chat-container:not([it-activated])::before,
 #chat-container[it-activated]::before {
 	background-color: #272727 !important;
 	border-radius: 8px !important;
@@ -202,25 +314,25 @@ html[it-hide-playlist='true'] ytd-playlist-panel-renderer#playlist,
 html[it-related-videos='hidden'] #related,
 html[it-related-videos='hidden'] #related #contents,
 html[it-related-videos='hidden'] #related #dismissible,
-html[it-related-videos='hidden'] #related > ytd-watch-next-secondary-results-renderer > #items,
+html[it-related-videos='hidden'] #related>ytd-watch-next-secondary-results-renderer>#items,
 html[data-page-type=video][it-related-videos='hidden'] ytd-compact-video-renderer,
-html[data-page-type=video][it-related-videos='hidetabs'] #related #chips, 
+html[data-page-type=video][it-related-videos='hidetabs'] #related #chips,
 html[it-hide-sidebar='true'] #related,
-html[it-hide-sidebar='true'] #related > ytd-watch-next-secondary-results-renderer > #items,
+html[it-hide-sidebar='true'] #related>ytd-watch-next-secondary-results-renderer>#items,
 html[it-hide-sidebar='true'] div#secondary div#panels,
 html[it-hide-sidebar='true'] div#secondary div#donation-shelf {
 	display: none !important
 }
 
-html[it-related-videos='collapsed'] #related > ytd-watch-next-secondary-results-renderer > #items:not([it-activated])::before {
+html[it-related-videos='collapsed'] #related>ytd-watch-next-secondary-results-renderer>#items:not([it-activated])::before {
 	content: 'Show more' !important;
 }
 
-html[it-related-videos='collapsed'] #related > ytd-watch-next-secondary-results-renderer > #items[it-activated]::before {
+html[it-related-videos='collapsed'] #related>ytd-watch-next-secondary-results-renderer>#items[it-activated]::before {
 	content: 'Show less' !important;
 }
 
-html[it-related-videos='collapsed'] #related > ytd-watch-next-secondary-results-renderer > #items::before {
+html[it-related-videos='collapsed'] #related>ytd-watch-next-secondary-results-renderer>#items::before {
 	font-family: inherit !important;
 	font-size: 1.6rem !important;
 	font-weight: 400 !important;
@@ -238,7 +350,7 @@ html[it-related-videos='collapsed'] #related > ytd-watch-next-secondary-results-
 	align-items: center !important;
 }
 
-html[it-related-videos='collapsed'] #related > ytd-watch-next-secondary-results-renderer > #items:not([it-activated]) > * {
+html[it-related-videos='collapsed'] #related>ytd-watch-next-secondary-results-renderer>#items:not([it-activated])>* {
 	visibility: hidden !important;
 	pointer-events: none !important;
 }
@@ -252,37 +364,43 @@ html[data-page-type=video][it-no-page-margin='true'] ytd-watch-flexy:not([fullsc
 html[data-page-type=video][it-no-page-margin='true'] ytd-watch-flexy:not([fullscreen]) #secondary.ytd-watch-flexy {
 	max-width: 100% !important;
 }
+
 html[data-page-type=video][it-no-page-margin='true'] ytd-watch-flexy:not([fullscreen]) #below {
 	margin-left: calc(4vh + 3vw - 40px) !important;
-} 	
+}
 
 @media screen and (max-width: 2300px) and (min-width: 1250px) {
 	html[data-page-type=video][it-no-page-margin='true'] ytd-watch-flexy:not([fullscreen]) #secondary.ytd-watch-flexy {
 		margin-right: calc (-12px - 0.4vw - 0.4vh) !important;
 	}
+
 	html[data-page-type=video][it-no-page-margin='true'] ytd-watch-flexy:not([fullscreen]) #below {
 		margin-left: max(18px, calc(19vw - 230px)) !important;
-		margin-right:max(18px, calc(13vw - 130px)) !important;
+		margin-right: max(18px, calc(13vw - 130px)) !important;
 		max-width: 1280px !important;
-	} 
+	}
 }
-	
+
 @media screen and (min-width: 2301px) {
 	html[data-page-type=video][it-no-page-margin='true'][it-sidebar-left='true'] #secondary {
 		left: 15px !important;
 	}
+
 	html[data-page-type=video][it-no-page-margin='true']:not([it-player-size='max_width']) #secondary {
-		position:absolute !important;  right: 15px;
+		position: absolute !important;
+		right: 15px;
 	}
+
 	html[data-page-type=video][it-no-page-margin='true']:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #primary.ytd-watch-flexy {
 		max-width: 1280px !important;
 	}
+
 	html[data-page-type=video][it-no-page-margin='true']:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #below {
 		margin-left: 10px !important;
 	}
-}	
+}
 
-html[data-page-type=video][it-no-page-margin='true'] ytd-browse > ytd-two-column-browse-results-renderer {
+html[data-page-type=video][it-no-page-margin='true'] ytd-browse>ytd-two-column-browse-results-renderer {
 	width: auto !important;
 	max-width: auto !important;
 }
@@ -306,7 +424,10 @@ html[data-page-type=video][it-sidebar-left='true'] #head>#upnext {
 	order: 5 !important;
 }
 
-html[data-page-type=video][it-sidebar-left='true'] #columns>#secondary>#related {margin-left: calc(0.5vw + 4px); margin-right:1vw !important;}
+html[data-page-type=video][it-sidebar-left='true'] #columns>#secondary>#related {
+	margin-left: calc(0.5vw + 4px);
+	margin-right: 1vw !important;
+}
 
 /*--------------------------------------------------------------
 # MOVE THUMBNAILS RIGHT
@@ -378,6 +499,3 @@ html[it-thumbnails-right='true'] #related yt-lockup-view-model .yt-lockup-view-m
 	margin-left: 12px !important;
 	margin-right: 0 !important;
 }
-
-  
-

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
@@ -44,7 +44,7 @@ extension.features.relatedVideos = function (anything) {
 
 extension.features.liveChat = function () {
 	if (extension.storage.get('livechat') === 'collapsed') {
-		window.addEventListener('click', function(event) {
+		window.addEventListener('click', function (event) {
 			if (extension.storage.get('livechat') !== 'collapsed') return;
 
 			var chat = event.target.closest('#chat-container');
@@ -64,6 +64,31 @@ extension.features.liveChat = function () {
 };
 
 /*--------------------------------------------------------------
+# TRANSCRIPT COLLAPSE
+--------------------------------------------------------------*/
+extension.features.transcriptCollapse = function () {
+	if (extension.storage.get('transcript_collapse') === true) {
+		window.addEventListener('click', function (event) {
+			if (extension.storage.get('transcript_collapse') !== true) return;
+
+
+			var header = event.target.closest('ytd-engagement-panel-section-list-renderer[target-id*="transcript"] #header');
+			if (!header) return;
+
+
+			if (event.target.closest('button') || event.target.closest('yt-icon-button')) return;
+
+
+			var panel = header.closest('ytd-engagement-panel-section-list-renderer');
+			if (panel) {
+				panel.toggleAttribute('it-activated');
+			}
+		}, true);
+	}
+};
+
+
+/*--------------------------------------------------------------
 # STICKY NAVIGATION
 --------------------------------------------------------------*/
 
@@ -73,14 +98,14 @@ extension.features.stickyNavigation = function () {
 		function ensureNavigationVisible() {
 			const miniGuide = document.querySelector('ytd-mini-guide-renderer');
 			const guide = document.querySelector('ytd-guide-renderer');
-			
+
 			if (miniGuide) {
 				miniGuide.style.transform = 'translateX(0)';
 				miniGuide.style.transition = 'none';
 				miniGuide.removeAttribute('hidden');
 				miniGuide.setAttribute('aria-hidden', 'false');
 			}
-			
+
 			if (guide) {
 				guide.style.transform = 'translateX(0)';
 				guide.style.transition = 'none';
@@ -93,9 +118,9 @@ extension.features.stickyNavigation = function () {
 		ensureNavigationVisible();
 
 		// Set up observer to watch for navigation changes
-		const observer = new MutationObserver(function(mutations) {
-			mutations.forEach(function(mutation) {
-				if (mutation.type === 'attributes' && 
+		const observer = new MutationObserver(function (mutations) {
+			mutations.forEach(function (mutation) {
+				if (mutation.type === 'attributes' &&
 					(mutation.attributeName === 'hidden' || mutation.attributeName === 'aria-hidden')) {
 					ensureNavigationVisible();
 				}
@@ -105,14 +130,14 @@ extension.features.stickyNavigation = function () {
 		// Observe navigation elements
 		const miniGuide = document.querySelector('ytd-mini-guide-renderer');
 		const guide = document.querySelector('ytd-guide-renderer');
-		
+
 		if (miniGuide) {
 			observer.observe(miniGuide, {
 				attributes: true,
 				attributeFilter: ['hidden', 'aria-hidden']
 			});
 		}
-		
+
 		if (guide) {
 			observer.observe(guide, {
 				attributes: true,

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -431,116 +431,116 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 					tags: "remove,hide"
 				},
 				hide_gradient_bottom: {
-				component: "switch",
-				text: "hideGradientBottom"
+					component: "switch",
+					text: "hideGradientBottom"
 				},
 				always_show_progress_bar: {
-				component: "switch",
-				text: "alwaysShowProgressBar"
+					component: "switch",
+					text: "alwaysShowProgressBar"
 				},
 				player_color: {
-				component: "select",
-				text: "playerColor",
-				options: [{
-					text: "default",
-					value: "default"
-				}, {
-					text: "red",
-					value: "red"
-				}, {
-					text: "pink",
-					value: "pink"
-				}, {
-					text: "purple",
-					value: "purple"
-				}, {
-					text: "deepPurple",
-					value: "deep_purple"
-				}, {
-					text: "indigo",
-					value: "indigo"
-				}, {
-					text: "blue",
-					value: "blue"
-				}, {
-					text: "lightBlue",
-					value: "light_blue"
-				}, {
-					text: "cyan",
-					value: "cyan"
-				}, {
-					text: "teal",
-					value: "teal"
-				}, {
-					text: "green",
-					value: "green"
-				}, {
-					text: "lightGreen",
-					value: "light_green"
-				}, {
-					text: "lime",
-					value: "lime"
-				}, {
-					text: "yellow",
-					value: "yellow"
-				}, {
-					text: "amber",
-					value: "amber"
-				}, {
-					text: "orange",
-					value: "orange"
-				}, {
-					text: "deepOrange",
-					value: "deep_orange"
-				}, {
-					text: "brown",
-					value: "brown"
-				}, {
-					text: "blueGray",
-					value: "blue_gray"
-				}, {
-					text: "white",
-					value: "white"
-				}],
-				tags: "style"
+					component: "select",
+					text: "playerColor",
+					options: [{
+						text: "default",
+						value: "default"
+					}, {
+						text: "red",
+						value: "red"
+					}, {
+						text: "pink",
+						value: "pink"
+					}, {
+						text: "purple",
+						value: "purple"
+					}, {
+						text: "deepPurple",
+						value: "deep_purple"
+					}, {
+						text: "indigo",
+						value: "indigo"
+					}, {
+						text: "blue",
+						value: "blue"
+					}, {
+						text: "lightBlue",
+						value: "light_blue"
+					}, {
+						text: "cyan",
+						value: "cyan"
+					}, {
+						text: "teal",
+						value: "teal"
+					}, {
+						text: "green",
+						value: "green"
+					}, {
+						text: "lightGreen",
+						value: "light_green"
+					}, {
+						text: "lime",
+						value: "lime"
+					}, {
+						text: "yellow",
+						value: "yellow"
+					}, {
+						text: "amber",
+						value: "amber"
+					}, {
+						text: "orange",
+						value: "orange"
+					}, {
+						text: "deepOrange",
+						value: "deep_orange"
+					}, {
+						text: "brown",
+						value: "brown"
+					}, {
+						text: "blueGray",
+						value: "blue_gray"
+					}, {
+						text: "white",
+						value: "white"
+					}],
+					tags: "style"
+				},
+				player_transparent_background: {
+					component: "switch",
+					text: "transparentBackground"
+				},
+				player_hide_skip_overlay: {
+					component: "switch",
+					text: "hideSkipOverlay",
+					value: false,
+					tags: "remove,hide"
+				},
+				player_hide_pause_overlay: {
+					component: "switch",
+					text: "hidePauseOverlay",
+					value: false,
+					tags: "remove,hide,pause,bezel"
+				},
+				duration_with_speed: {
+					component: "switch",
+					text: "durationWithSpeed",
+					value: false
+				},
+				player_hd_thumbnail: {
+					component: "switch",
+					text: "hdThumbnail",
+					tags: "preview"
+				},
+				hide_scroll_for_details: {
+					component: "switch",
+					text: "hideScrollForDetails",
+					tags: "remove,hide"
+				},
+				hide_top_loading_bar: {
+					component: "switch",
+					text: "hideTopLoadingBar",
+					tags: "remove,hide"
+				}
 			},
-			player_transparent_background: {
-				component: "switch",
-				text: "transparentBackground"
-			},
-			player_hide_skip_overlay: {
-				component: "switch",
-				text: "hideSkipOverlay",
-				value: false,
-				tags: "remove,hide"
-			},
-			player_hide_pause_overlay: {
-				component: "switch",
-				text: "hidePauseOverlay",
-				value: false,
-				tags: "remove,hide,pause,bezel"
-			},
-			duration_with_speed: {
-				component: "switch",
-				text: "durationWithSpeed",
-				value: false
-			},
-			player_hd_thumbnail: {
-				component: "switch",
-				text: "hdThumbnail",
-				tags: "preview"
-			},
-			hide_scroll_for_details: {
-				component: "switch",
-				text: "hideScrollForDetails",
-				tags: "remove,hide"
-			},
-			hide_top_loading_bar: {
-				component: "switch",
-				text: "hideTopLoadingBar",
-				tags: "remove,hide"
-			}
-		},	
 			section_2: {
 				component: 'section',
 				variant: 'card',
@@ -1075,6 +1075,11 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 					}
 				}
 			},
+			transcript_collapse: {
+				component: "switch",
+				text: "transcriptCollapse"
+			},
+
 			compact_spacing: {
 				component: "switch",
 				text: 'compact_spacing',


### PR DESCRIPTION
- Added a new `transcriptCollapse` toggle to the Appearance > Sidebar menu
- Implemented click listener in `sidebar.js` to toggle the transcript's expanded/collapsed state
- Added CSS rules in `sidebar.css` to hide the transcript text when collapsed
- Updated `messages.json` with the new setting localization string