### PR TITLE
fix(player): skip redundant seekTo(0) when video is already at start

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -7,9 +7,17 @@ ImprovedTube.forcedPlayVideoFromTheBeginning = function () {
 		paused = video?.paused;
 
 	if (player && video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
-		player.seekTo(0);
-		// restore previous paused state
-		if (paused) { player.pauseVideo(); }
+		// Skip the seek when the video is effectively already at 0. When
+		// YouTube's own playback starts at 0 (fresh video, never watched), a
+		// seekTo(0) after page load produces an audible "double play" of the
+		// opening moments. Only seek when YouTube has resumed from a saved
+		// timestamp (currentTime > 0), which is the case this setting exists
+		// to override.
+		if (video.currentTime > 0.5) {
+			player.seekTo(0);
+			// restore previous paused state after the seek
+			if (paused) { player.pauseVideo(); }
+		}
 	}
 };
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #3806: when `Force video to play from the beginning` is ON and the user opens a fresh (never-watched) video, the opening moments played twice. Now `forcedPlayVideoFromTheBeginning` only seeks when YouTube has resumed from a saved timestamp; when the video is already at 0 it does nothing.

## Why this matters

The issue (awsidequest) describes it well:

> YouTube starts playing videos from users saved timestamps before complete webpage is loaded, but the extension replays the video from 0s only after complete webpage is loaded I think. Leading to a double play at the start.

Looking at `js&css/web-accessible/www.youtube.com/player.js:4-14`, the function unconditionally called `player.seekTo(0)` whenever the feature was on and the URL was `/watch`:

```js
if (player && video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
    player.seekTo(0);
    // restore previous paused state
    if (paused) { player.pauseVideo(); }
}
```

Two cases:

- **Resumed video (`currentTime > 0`)** — YouTube picks up from the saved timestamp, the extension seeks to 0. This is the case the setting exists to support. Seek is needed.
- **Fresh video (`currentTime ≈ 0`)** — YouTube's own playback starts at 0 during early page load, then the extension's `seekTo(0)` after load triggers a re-start. The video "double plays" the opening moments. This is the reported bug.

The issue's suggested mitigation:

> the extension should 'do nothing' if the video timestamp is already 0s. This at least takes care of the most annoying/noticeable case of the initial moments of the video double playing/replaying.

## Changes

`js&css/web-accessible/www.youtube.com/player.js` (+11 / -3):

- Guard `player.seekTo(0)` behind `video.currentTime > 0.5`. The 0.5s threshold swallows the case where YouTube started at a tiny offset (0.0-0.1s is effectively "fresh") without missing any real saved-timestamp resume.
- Move the paused-state restore inside the seek branch. Without that, we were calling `player.pauseVideo()` even when we didn't change state — a spurious extra call in the no-seek path.

Six-line behavioral change; no new dependencies or APIs.

## Testing

- `node --check` on the edited file: syntax OK.
- `npm test`: same pass/fail counts as on `master` (the pre-existing `day-of-week.test.js` failure is unrelated; my change doesn't touch that area).
- Manual verification requires loading the unpacked extension in Chrome with `Force video to play from the beginning` enabled and opening a never-watched video. I didn't do that step; happy to iterate on the diff based on maintainer testing.

## AI disclosure

This contribution was developed with AI assistance (Claude Code).
