### PR TITLE
apply player color to Shorts progress bar

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -142,8 +142,10 @@ html[it-player-color]:not([it-player-color='default']):not([it-player-color='nor
 	background-color: var(--it-player-color) !important;
 }
 
-html[it-player-color]:not([it-player-color='default']):not([it-player-color='normal']) .ytp-swatch-color {
-	color: var(--it-player-color) !important;
+html[it-player-color]:not([it-player-color='default']):not([it-player-color='normal']) ytd-shorts .ytProgressBarLineProgressBarPlayed,
+html[it-player-color]:not([it-player-color='default']):not([it-player-color='normal']) ytd-shorts .YtProgressBarLineProgressBarPlayedRefresh {
+    background: var(--it-player-color) !important;
+    background-color: var(--it-player-color) !important;
 }
 
 html[it-player-color]:not([it-player-color='default']):not([it-player-color='normal']) .ytp-settings-button.ytp-hd-quality-badge:after{
@@ -799,4 +801,9 @@ html[it-player-hide-pause-overlay='true'] .ytp-pause-overlay {
     -webkit-background-size: contain !important;
     -moz-background-size: contain !important;
     background-color: #000 !important;
+}
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) ytd-shorts .ytProgressBarLineProgressBarPlayed,
+html[it-player-color]:not([it-player-color='red']):not([it-player-color='normal']) ytd-shorts .YtProgressBarLineProgressBarPlayedRefresh {
+    background: var(--it-player-color) !important;
+    background-color: var(--it-player-color) !important;
 }


### PR DESCRIPTION
Closes #2748

## Changes
- Extended existing player color CSS rule in player.css to also apply to the Shorts progress bar
- Targets both `ytProgressBarLineProgressBarPlayed` and `YtProgressBarLineProgressBarPlayedRefresh` classes for full compatibility

## Testing
- Set Player → Progress bar color to any color (e.g. yellow/blue)
- Verified Shorts progress bar now matches the selected color
- Verified default red is unchanged when no color is selected