### PR TITLE
fix: expand video when chat replay is hidden (#3826)

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2343,3 +2343,12 @@ html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd
 html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer[is-empty] {
     display: none !important;
 }
+/* Fix: expand video when chat replay is hidden */
+html[it-hide-chat-replay=true] #secondary {
+  display: none !important;
+}
+
+html[it-hide-chat-replay=true] #primary {
+  width: 100% !important;
+  max-width: 100% !important;
+}


### PR DESCRIPTION
## 🐛 Fix: Hide chat replay layout issue

- Removed empty space left by hidden chat replay
- Ensured video expands to full width

Closes #3826