### PR TITLE
fix(player): remove 1x speed button when speed buttons are disabled

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -361,6 +361,7 @@ document.addEventListener('it-message-from-extension', function () {
 				case 'playerIncreaseDecreaseSpeedButtons':
 					if (ImprovedTube.storage.player_increase_decrease_speed_buttons === false) {
 						ImprovedTube.elements.buttons['it-increase-speed-button']?.remove();
+						ImprovedTube.elements.buttons['it-1x-speed-button']?.remove();
 						ImprovedTube.elements.buttons['it-decrease-speed-button']?.remove();
 					}
 					break


### PR DESCRIPTION
issue : #3830 
-> This PR fixes an issue where the playback speed indicator button (1x) remains visible in the YouTube player after disabling the "Increase/Decrease Speed buttons" option.

Root Cause->
In js&css/web-accessible/core.js (around line 361), the cleanup logic only removes the increment (+) and decrement (-) buttons, but does not handle removal of the playback speed indicator (1x) element.

chnage->Added removal logic for the 1x playback speed button alongside existing button cleanup