### PR TITLE
fix: remove 1x speed button when disabling feature

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -362,6 +362,7 @@ document.addEventListener('it-message-from-extension', function () {
 					if (ImprovedTube.storage.player_increase_decrease_speed_buttons === false) {
 						ImprovedTube.elements.buttons['it-increase-speed-button']?.remove();
 						ImprovedTube.elements.buttons['it-decrease-speed-button']?.remove();
+						ImprovedTube.elements.buttons['it-1x-speed-button']?.remove();
 					}
 					break
 


### PR DESCRIPTION
Fixes an issue where the "1x" playback speed button remains visible after disabling the "Increase/Decrease Speed buttons" feature.

Added removal of the 'it-1x-speed-button' element when the feature is disabled.