### PR TITLE
fix: Prevent forced playback speed exception when DATA.title is false

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -197,7 +197,7 @@ const waitForVideoTitle = setInterval(() => { const title = ImprovedTube.videoTi
 if (title && title !== 'YouTube') {
     clearInterval(waitForVideoTitle);
 			 DATA.videoID = ImprovedTube.videoId() || false;     // console.log("SPEED: TITLE:" + ImprovedTube.videoTitle() + DATA.title); 
-			 if ( DATA.title === ImprovedTube.videoTitle() || DATA.title.replace(/\s{2,}/g, ' ') === ImprovedTube.videoTitle() )
+			 if ( DATA.title && (DATA.title === ImprovedTube.videoTitle() || DATA.title.replace(/\s{2,}/g, ' ') === ImprovedTube.videoTitle()) )
 				{ keywords = document.querySelector('meta[name="keywords"]')?.content || ''; ImprovedTube.speedException(); }
 				else { keywords = ''; (async function () { try { const response = await fetch(`https://www.youtube.com/watch?v=${DATA.videoID}`);
 					console.log("loading the html source:" + `https://www.youtube.com/watch?v=${DATA.videoID}`);


### PR DESCRIPTION
# Summary
This PR fixes an exception in `ImprovedTube.playerPlaybackSpeed()` when "Permanent/Forced playback speed" is enabled and the playback speed is set above 1.

The code could call `.replace()` on `DATA.title` even when `DATA.title` was false, causing execution to stop.

# Details
Fixes an exception during execution.

[Console Log] Uncaught TypeError: DATA.title.replace is not a function  (player.js:227:65)

(Verified on version 4.2026)

Steps to reproduce:
- Reload and go to YouTube Home.
- Navigate to the "Playlists" or "History" page from the side menu.
- Execution stops due to the exception (visible in DevTools console).

# Environment
- Browser: Firefox Developer Edition 151 / Firefox 150
- Extension: ImprovedTube 4.2026 (No other extensions installed)
- OS: macOS 15.7
