### PR TITLE
fix: Correct metadata parsing for forced playback speed

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -202,7 +202,7 @@ if (title && title !== 'YouTube') {
 				else { keywords = ''; (async function () { try { const response = await fetch(`https://www.youtube.com/watch?v=${DATA.videoID}`);
 					console.log("loading the html source:" + `https://www.youtube.com/watch?v=${DATA.videoID}`);
 					const htmlContent = await response.text();
-					const metaRegex = /<meta[^>]+(name|itemprop)=["'](keywords|genre|duration)["'][^>]+content=["']([^"']+)["'][^>]*>/gi;
+					const metaRegex = /<meta[^>]+(?:name|itemprop)=["'](keywords|genre|duration|title)["'][^>]+content=["']([^"']+)["'][^>]*>/gi;
 					let match; while ((match = metaRegex.exec(htmlContent)) !== null) { // console.log(match);
 						const [, property, value] = match;
 						if (property === 'keywords') { keywords = value;} else {DATA[property] = value;}


### PR DESCRIPTION

# Summary
This PR fixes metadata extraction in `ImprovedTube.playerPlaybackSpeed()` when "Permanent/Forced playback speed" is enabled and the playback speed is set above 1.

Video title changes were not always detected correctly because fetched metadata was parsed with a faulty regex.

# Details
Fixed an issue where video title changes were not being correctly detected due to a faulty regex.

The subsequent logic expects property/value in `match[1]` and `match[2]`, but the current regex captures them into `match[2]` and `match[3]`. This mismatch causes `if (keywords) { ImprovedTube.speedException(); }` to always evaluate to false, preventing music video detection.

Additionally, the code failed to extract the title from fetched content, leading to evaluations based on outdated metadata from the previous video.

Changes:
- Exclude `(name|itemprop)` from capture groups to fix an index mismatch for property and value.
- Update regex to match `<meat name="title">` for extracting `DATA.title` from the fetched content.
- Fixes the bug where `ImprovedTube.speedException()` is never triggered due to failed keyword retrieval.

# Environment
- Browser: Firefox Developer Edition 151 / Firefox 150
- Extension: ImprovedTube 4.2026 (No other extensions installed)
- OS: macOS 15.7
