### PR TITLE
fix: Prevent forced playback speed interval leak

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -165,16 +165,22 @@ ImprovedTube.playerPlaybackSpeed = function () { if (this.storage.player_forced_
 				)	{ player.setPlaybackRate(1); video.playbackRate = 1; console.log ("...,thus must be music?"); }
 				else { 	// Now this video might rarely be music
 					// - however we can make extra-sure after waiting for the video descripion to load... (#1539)
-					var tries = 0; 	var intervalMs = 210; if (location.href.indexOf('/watch?') !== -1) {var maxTries = 10;} else {var maxTries = 0;}
-					// ...except when it is an embedded player?
-					var waitForDescription = setInterval(() => {
-						if (++tries >= maxTries) {
-							subtitle = document.querySelector('#title + #subtitle:last-of-type')
-							if ( subtitle && 1 <= Number((subtitle?.innerHTML?.match(/^\d+/) || [])[0])	// indicates buyable/registered music (amount of songs)
-						 && typeof testSongDuration(DATA.lengthSeconds, Number((subtitle?.innerHTML?.match(/^\d+/) || [])[0]) ) !== 'undefined' ) // resonable duration
-							{player.setPlaybackRate(1); video.playbackRate = 1; console.log("...but YouTube shows music below the description!"); clearInterval(waitForDescription); }
-							intervalMs *= 1.11;	}}, intervalMs);
-					window.addEventListener('load', () => { setTimeout(() => { clearInterval(waitForDescription); }, 1234); });
+					if (location.href.indexOf('/watch?') !== -1) {
+						let tries = 0;
+						const intervalMs = 210;
+						const maxTries = 10;
+						const waitForDescription = setInterval(() => {
+							const subtitle = document.querySelector('#title + #subtitle:last-of-type');
+							// console.log("[SPEED] checking for music keywords in the description... try " + tries + "// subtitle: " + subtitle?.innerHTML);
+							const descriptionSongCount = Number((subtitle?.innerHTML?.match(/^\d+/) || [])[0]);
+							if (subtitle && 1 <= descriptionSongCount && typeof testSongDuration(DATA.lengthSeconds, descriptionSongCount) !== 'undefined')
+							{player.setPlaybackRate(1); video.playbackRate = 1; console.log("...but YouTube shows music below the description!"); clearInterval(waitForDescription); return; }
+							if (++tries >= maxTries) {
+								// console.log("[SPEED] max tries reached, stopping description check...");
+								clearInterval(waitForDescription);
+							}
+						}, intervalMs);
+					}
 				}
 			}
 			//DATA  (TO-DO: make the Data available to more/all features? #1452  #1763  (Then can replace ImprovedTube.elements.category === 'music', VideoID is also used elsewhere)


### PR DESCRIPTION

# Summary
This PR fixes a leaked description-check interval in `ImprovedTube.playerPlaybackSpeed()` when "Permanent/Forced playback speed" is enabled and the playback speed is set above 1.

The current description-check interval can keep running indefinitely.

# Details
The existing code only clears `waitForDescription` when the music subtitle check succeeds, or when the `window.load` event fires. On YouTube, video navigation often happens inside the SPA without a new `window.load` event. Also, this code may run after `load` has already fired, so the listener will never execute. In those cases, if the subtitle check does not match, the interval is never cleared.

The fix makes the interval self-contained:

- Run the description check only on `/watch?` pages.
- Check the subtitle on every interval tick.
- Clear the interval immediately when a music subtitle match is found.
- Clear the interval once `maxTries` is reached, even when no match is found.

This prevents a leaked interval while preserving the intended short retry window for delayed YouTube description content, although this may slightly differ from the original implementation's intent.

## Notes on Reproduction
To reproduce this leak, simply play any non-music video. Please note that the persistent execution of the interval is not visible unless you insert a `console.log()` for tracking.

# Environment
- Browser: Firefox Developer Edition 151 / Firefox 150
- Extension: ImprovedTube 4.2026 (No other extensions installed)
- OS: macOS 15.7
