### PR TITLE
Add squared thumbnails option

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1397,6 +1397,9 @@
   "squaredUserImages": {
     "message": "Squared user images"
   },
+  "squaredThumbnails": {
+    "message": "Squared thumbnails"
+  },
   "static": {
     "message": "Static"
   },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -14,6 +14,7 @@
 # Hide buttons on thumbnails
 # Hide thumbnail icon
 # Hide dots on thumbnails
+# Squared thumbnails
 --------------------------------------------------------------*/
 html[it-cursorLighting=true] #below			{opacity:.4; transition:3s;}
 html[it-cursorLighting=true] #below:hover	{opacity:1; transition:.5s;}
@@ -50,6 +51,22 @@ html[it-cursorLighting=true]:not([data-page-type=video]) #guide-content,
 html[it-cursorLighting=true] ytd-mini-guide-renderer 		{opacity:.4; transition:2s}					
 html[it-cursorLighting=true]:not([data-page-type=video]) #guide-content:hover,
 html[it-cursorLighting=true] ytd-mini-guide-renderer:hover	{opacity:1; transition:.3s}
+
+/*--------------------------------------------------------------
+# SQUARED THUMBNAILS
+--------------------------------------------------------------*/
+html[it-squared-thumbnails='true'] ytd-thumbnail #thumbnail,
+html[it-squared-thumbnails='true'] ytd-thumbnail img,
+html[it-squared-thumbnails='true'] ytd-playlist-thumbnail #thumbnail,
+html[it-squared-thumbnails='true'] ytd-playlist-thumbnail img,
+html[it-squared-thumbnails='true'] .yt-thumbnail-view-model,
+html[it-squared-thumbnails='true'] .yt-thumbnail-view-model img,
+html[it-squared-thumbnails='true'] .yt-lockup-view-model-wiz__content-image,
+html[it-squared-thumbnails='true'] .yt-lockup-view-model-wiz__content-image img,
+html[it-squared-thumbnails='true'] .yt-video-card-view-model__thumbnail,
+html[it-squared-thumbnails='true'] .yt-video-card-view-model__thumbnail img {
+	border-radius: 0 !important;
+}
 
 /*--------------------------------------------------------------
 HIDING STUFF   (display:none !important) (Usually the !important isn't necessary)

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -265,6 +265,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideThumbnailDots',
 					tags: 'preview'
 				},
+				squared_thumbnails: {
+					component: 'switch',
+					text: 'squaredThumbnails',
+					tags: 'thumbnail square radius rounded corners'
+				},
 				thumbnails_quality: {
 					component: 'select',
 					text: 'thumbnailsQuality',

--- a/tests/unit/squared-thumbnails.test.js
+++ b/tests/unit/squared-thumbnails.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Squared thumbnails option', () => {
+	let generalCss;
+	let generalMenu;
+	let enMessages;
+
+	beforeAll(() => {
+		generalCss = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.css'), 'utf8');
+		generalMenu = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/general.js'), 'utf8');
+		enMessages = fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8');
+	});
+
+	test('adds a thumbnails settings switch', () => {
+		expect(generalMenu).toContain('squared_thumbnails');
+		expect(generalMenu).toContain("text: 'squaredThumbnails'");
+	});
+
+	test('localizes the switch label', () => {
+		expect(enMessages).toContain('"squaredThumbnails"');
+		expect(enMessages).toContain('"Squared thumbnails"');
+	});
+
+	test('removes border radius from current thumbnail containers', () => {
+		expect(generalCss).toContain("html[it-squared-thumbnails='true'] ytd-thumbnail #thumbnail");
+		expect(generalCss).toContain("html[it-squared-thumbnails='true'] .yt-thumbnail-view-model");
+		expect(generalCss).toContain('border-radius: 0 !important;');
+	});
+});


### PR DESCRIPTION
Fixes #1549

## Summary
- Adds a Squared thumbnails switch under General -> Thumbnails.
- Removes border radius from current YouTube thumbnail containers and images when the option is enabled.
- Adds static unit coverage for the setting, locale key, and CSS selectors.

## Test
- `npx jest tests/unit/squared-thumbnails.test.js --runInBand`

Note: the full test suite has an existing timezone-sensitive failure in `tests/unit/day-of-week.test.js` on this machine; the new targeted test passes.