### PR TITLE
Add Watch Later button option to thumbnails

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1130,6 +1130,9 @@
   "popupWindowButtons": {
     "message": "Add a popup-player-button to each thumbnail"
   },
+  "watchLaterButtons": {
+    "message": "Add a Watch Later button to thumbnails"
+  },
   "position": {
     "message": "Position"
   },

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -43,7 +43,6 @@ extension.events.on('init', function () {
 	extension.features.confirmationBeforeClosing();
 	extension.features.defaultContentCountry();
 	extension.features.popupWindowButtons();
-	extension.features.watchLaterButtons();
 	extension.features.disableThumbnailPlayback();
 	extension.features.muteThumbnailPreviews();
 	extension.features.markWatchedVideos();
@@ -54,6 +53,7 @@ extension.events.on('init', function () {
 	extension.features.openNewTab();
 	extension.features.removeListParamOnNewTab();
 	extension.features.removeMemberOnly();
+	if ( extension.storage.get('watch_later_buttons') && extension.storage.get('watch_later_buttons') !== 'disabled' ) { 	extension.features.watchLaterButtons(); }
 	// extension.features.hideSponsoredVideosOnHome?.();
 	bodyReady();
 });

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -43,6 +43,7 @@ extension.events.on('init', function () {
 	extension.features.confirmationBeforeClosing();
 	extension.features.defaultContentCountry();
 	extension.features.popupWindowButtons();
+	extension.features.watchLaterButtons();
 	extension.features.disableThumbnailPlayback();
 	extension.features.muteThumbnailPreviews();
 	extension.features.markWatchedVideos();

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -357,6 +357,55 @@ html[it-scroll-to-top='true'] #it-scroll-to-top:hover {
 	transition: opacity 0s;
 }
 /*--------------------------------------------------------------
+# Watch Later Button
+--------------------------------------------------------------*/
+.it-watch-later-button {
+	font-family: inherit !important;
+
+	position: absolute !important;
+	z-index: 1000 !important;
+	top: 4px !important;
+	right: 4px !important;
+
+	visibility: hidden !important;
+	opacity: 0 !important;
+	transition: opacity 150ms !important;
+
+	width: 28px !important;
+	height: 28px !important;
+	padding: 4px !important;
+
+	cursor: pointer !important;
+	text-align: center !important;
+
+	color: #fff !important;
+	border: none !important;
+	border-radius: 2px !important;
+	background: rgba(0, 0, 0, .8) !important;
+
+	fill: currentColor !important;
+}
+
+.it-watch-later-button svg {
+	width: 20px !important;
+	height: 20px !important;
+	pointer-events: none !important;
+}
+
+html[it-watch-later-buttons='always'] .it-watch-later-button,
+html[it-watch-later-buttons='hover'] *:hover>.it-watch-later-button {
+	visibility: visible !important;
+	opacity: 1 !important;
+}
+
+.it-watch-later-button[data-state='added'] {
+	background: rgba(0, 96, 64, .9) !important;
+}
+
+.it-watch-later-button[data-state='unavailable'] {
+	background: rgba(153, 27, 27, .9) !important;
+}
+/*--------------------------------------------------------------
 # MARK WATCHED VIDEOS
 --------------------------------------------------------------*/
 .it-mark-watched-videos {

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -8,6 +8,7 @@
 # Confirmation before closing
 # Default content country
 # Add "Popup window" buttons
+# Add "Watch Later" buttons
 # Font
 # Mark watched videos
 # Track watched videos
@@ -308,6 +309,226 @@ extension.features.popupWindowButtons = function (event) {
 			window.addEventListener('mouseover', this.popupWindowButtons, true);
 		} else {
 			window.removeEventListener('mouseover', this.popupWindowButtons, true);
+		}
+	}
+};
+/*--------------------------------------------------------------
+# ADD "WATCH LATER" BUTTONS
+--------------------------------------------------------------*/
+extension.features.watchLaterButtons = function (event) {
+	function getVideoId(url) {
+		if (!url) {
+			return null;
+		}
+
+		var watchMatch = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/),
+			shortsMatch = url.match(/\/shorts\/([a-zA-Z0-9_-]{11})/);
+
+		return watchMatch ? watchMatch[1] : shortsMatch ? shortsMatch[1] : null;
+	}
+
+	function findThumbnail(target) {
+		while (target && target.parentNode) {
+			if (
+				target.nodeName === 'A' &&
+				target.href &&
+				(
+					target.id === 'thumbnail' ||
+					(target.className && typeof target.className === 'string' && target.className.indexOf('thumb-link') !== -1)
+				)
+			) {
+				return target;
+			}
+
+			target = target.parentNode;
+		}
+	}
+
+	function findNativeWatchLaterButton(thumbnail) {
+		var container = thumbnail.closest('ytd-rich-item-renderer, ytd-video-renderer, ytd-grid-video-renderer, ytd-compact-video-renderer, ytd-playlist-video-renderer, yt-lockup-view-model') || thumbnail,
+			button = container.querySelector('button[aria-label*="Watch later" i], button[title*="Watch later" i]');
+
+		if (button) {
+			return button;
+		}
+
+		return thumbnail.querySelector('ytd-thumbnail-overlay-toggle-button-renderer button');
+	}
+
+	function getYtConfigValue(key) {
+		var pattern = new RegExp('"' + key + '":"([^"]+)"'),
+			scripts = document.scripts;
+
+		for (var i = 0, l = scripts.length; i < l; i++) {
+			var match = scripts[i].textContent.match(pattern);
+
+			if (match) {
+				return match[1];
+			}
+		}
+	}
+
+	function getYtConfigObject(key) {
+		var pattern = new RegExp('"' + key + '":(\\{.*?\\}),"' + key.replace(/_CONTEXT$/, '') + '_'),
+			scripts = document.scripts;
+
+		for (var i = 0, l = scripts.length; i < l; i++) {
+			var match = scripts[i].textContent.match(pattern);
+
+			if (match) {
+				try {
+					return JSON.parse(match[1]);
+				} catch (error) {
+					console.warn('[ImprovedTube] Unable to parse YouTube config object:', key, error);
+				}
+			}
+		}
+	}
+
+	function addWithInnertube(videoId, button) {
+		var apiKey = getYtConfigValue('INNERTUBE_API_KEY'),
+			context = getYtConfigObject('INNERTUBE_CONTEXT'),
+			clientVersion = getYtConfigValue('INNERTUBE_CLIENT_VERSION');
+
+		if (!context && clientVersion) {
+			context = {
+				client: {
+					clientName: 'WEB',
+					clientVersion: clientVersion
+				}
+			};
+		}
+
+		if (!apiKey || !context) {
+			button.dataset.state = 'unavailable';
+			return;
+		}
+
+		button.dataset.state = 'loading';
+
+		fetch('/youtubei/v1/browse/edit_playlist?key=' + apiKey, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'content-type': 'application/json'
+			},
+			body: JSON.stringify({
+				context: context,
+				playlistId: 'WL',
+				actions: [{
+					action: 'ACTION_ADD_VIDEO',
+					addedVideoId: videoId
+				}]
+			})
+		}).then(function (response) {
+			button.dataset.state = response.ok ? 'added' : 'unavailable';
+		}).catch(function () {
+			button.dataset.state = 'unavailable';
+		});
+	}
+
+	function addWatchLaterButton(thumbnail) {
+		var videoId = thumbnail ? getVideoId(thumbnail.href) : null;
+
+		if (thumbnail && thumbnail.itWatchLaterButton && !thumbnail.contains(thumbnail.itWatchLaterButton)) {
+			thumbnail.itWatchLaterButton = null;
+		}
+
+		if (thumbnail && videoId && !thumbnail.itWatchLaterButton) {
+			var button = document.createElement('button'),
+				svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+				path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+			button.type = 'button';
+			button.className = 'it-watch-later-button';
+			button.dataset.id = videoId;
+			button.title = 'Watch later';
+			button.setAttribute('aria-label', 'Add to Watch Later');
+
+			svg.setAttribute('viewBox', '0 0 24 24');
+			path.setAttribute('d', 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm0 18.2A8.2 8.2 0 1 1 20.2 12 8.2 8.2 0 0 1 12 20.2Zm.7-13.2h-1.8v5.8l5 3 .9-1.5-4.1-2.4Z');
+			svg.appendChild(path);
+			button.appendChild(svg);
+			thumbnail.appendChild(button);
+			thumbnail.itWatchLaterButton = button;
+
+			button.addEventListener('click', function (clickEvent) {
+				var nativeButton = findNativeWatchLaterButton(this.parentElement),
+					id = this.dataset.id;
+
+				clickEvent.preventDefault();
+				clickEvent.stopPropagation();
+				clickEvent.stopImmediatePropagation();
+
+				if (nativeButton && nativeButton !== this) {
+					nativeButton.click();
+					this.dataset.state = 'added';
+				} else {
+					addWithInnertube(id, this);
+				}
+			});
+		}
+	}
+
+	function addWatchLaterButtons(root) {
+		var thumbnails = (root || document).querySelectorAll ? (root || document).querySelectorAll('a#thumbnail, a.thumb-link') : [];
+
+		for (var i = 0, l = thumbnails.length; i < l; i++) {
+			addWatchLaterButton(thumbnails[i]);
+		}
+	}
+
+	function removeWatchLaterButtons() {
+		var buttons = document.querySelectorAll('.it-watch-later-button');
+
+		for (var i = 0, l = buttons.length; i < l; i++) {
+			if (buttons[i].parentElement) {
+				buttons[i].parentElement.itWatchLaterButton = null;
+			}
+
+			buttons[i].remove();
+		}
+	}
+
+	if (event instanceof Event) {
+		if (event.type === 'mouseover' && event.target) {
+			addWatchLaterButton(findThumbnail(event.target));
+		}
+	} else {
+		var option = extension.storage.get('watch_later_buttons');
+
+		window.removeEventListener('mouseover', this.watchLaterButtons, true);
+
+		if (this.watchLaterButtons.observer) {
+			this.watchLaterButtons.observer.disconnect();
+			this.watchLaterButtons.observer = null;
+		}
+
+		if (!option || option === 'disabled') {
+			removeWatchLaterButtons();
+		} else if (option === 'hover' || option === 'always') {
+			window.addEventListener('mouseover', this.watchLaterButtons, true);
+
+			if (option === 'always') {
+				if (document.body) {
+					addWatchLaterButtons(document);
+					this.watchLaterButtons.observer = new MutationObserver(function (mutationList) {
+						for (var i = 0, l = mutationList.length; i < l; i++) {
+							for (var j = 0, m = mutationList[i].addedNodes.length; j < m; j++) {
+								addWatchLaterButtons(mutationList[i].addedNodes[j]);
+							}
+						}
+					});
+					this.watchLaterButtons.observer.observe(document.body, {
+						childList: true,
+						subtree: true
+					});
+				} else {
+					setTimeout(function () {
+						extension.features.watchLaterButtons();
+					}, 100);
+				}
+			}
 		}
 	}
 };

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -250,6 +250,21 @@ extension.skeleton.main.layers.section.general = {
 					component: 'switch',
 					text: 'popupWindowButtons',
 				},
+				watch_later_buttons: {
+					component: 'select',
+					text: 'watchLaterButtons',
+					options: [{
+						text: 'disabled',
+						value: 'disabled'
+					}, {
+						text: 'hover',
+						value: 'hover'
+					}, {
+						text: 'always',
+						value: 'always'
+					}],
+					tags: 'watch later save thumbnail'
+				},
 				hide_thumbnail_overlay: {
 					component: 'switch',
 					text: 'hideThumbnailOverlay',

--- a/tests/unit/watch-later-buttons.test.js
+++ b/tests/unit/watch-later-buttons.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Watch Later thumbnail buttons', () => {
+	let generalJs;
+	let generalCss;
+	let generalSkeleton;
+
+	beforeAll(() => {
+		generalJs = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.js'), 'utf8');
+		generalCss = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.css'), 'utf8');
+		generalSkeleton = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/general.js'), 'utf8');
+	});
+
+	test('registers the feature with init', () => {
+		const initJs = fs.readFileSync(path.join(__dirname, '../../js&css/extension/init.js'), 'utf8');
+
+		expect(initJs).toContain('extension.features.watchLaterButtons();');
+		expect(generalJs).toContain('extension.features.watchLaterButtons');
+	});
+
+	test('adds a hover and always menu option', () => {
+		expect(generalSkeleton).toContain('watch_later_buttons');
+		expect(generalSkeleton).toContain("value: 'hover'");
+		expect(generalSkeleton).toContain("value: 'always'");
+	});
+
+	test('uses the native Watch Later control before the Innertube fallback', () => {
+		expect(generalJs).toContain('findNativeWatchLaterButton');
+		expect(generalJs).toContain('nativeButton.click();');
+		expect(generalJs).toContain('ACTION_ADD_VIDEO');
+		expect(generalJs).toContain("playlistId: 'WL'");
+	});
+
+	test('styles hover and always visibility states', () => {
+		expect(generalCss).toContain(".it-watch-later-button");
+		expect(generalCss).toContain("html[it-watch-later-buttons='hover']");
+		expect(generalCss).toContain("html[it-watch-later-buttons='always']");
+	});
+});


### PR DESCRIPTION
Summary
- adds a thumbnail setting for Watch Later buttons with disabled, hover, and always modes
- injects the button through the existing general content script wiring instead of a standalone file
- uses YouTube's native Watch Later control when available, with an Innertube add-to-WL fallback
- adds CSS, English locale text, and static unit coverage for the wiring

Fixes #1201

Verification
- npm test -- --runInBand
- npm run lint
- node --check js&css/extension/www.youtube.com/general/general.js
- git diff --check