### PR TITLE
fix: hide member-only channel videos with current badges

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -134,7 +134,10 @@ html[it-embeddedHideShare='true'][it-pathname^="/embed"] .ytp-share-button-visib
 # REMOVE MEMBER ONLY VIDEOS
 --------------------------------------------------------------*/
 html[it-remove-member-only='true'] ytd-grid-video-renderer:has(.badge-style-type-members-only),
+html[it-remove-member-only='true'] ytd-grid-video-renderer:has(badge-shape.yt-badge-shape--membership),
 html[it-remove-member-only='true'] ytd-rich-item-renderer:has(.badge-style-type-members-only),
+html[it-remove-member-only='true'] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership),
+html[it-remove-member-only='true'] yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership),
 html[it-remove-member-only='true'] yt-lockup-view-model:has(.yt-badge-shape--commerce),
 /*--------------------------------------------------------------
 # REMOVE CONTEXT BUTTONS ON SHORTS

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -1137,7 +1137,8 @@ extension.features.removeMemberOnly = function () {
 				display: none !important;
 			}
 			ytd-grid-video-renderer:has(badge-shape.yt-badge-shape--membership),
-			ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership) {
+			ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership),
+			yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership) {
 				display: none !important;
 			}
 		`;

--- a/tests/unit/member-only-hiding.test.js
+++ b/tests/unit/member-only-hiding.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Member-only video hiding (#3862)', () => {
+	let generalCssContent;
+	let generalJsContent;
+
+	beforeAll(() => {
+		generalCssContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.css'),
+			'utf8'
+		);
+		generalJsContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.js'),
+			'utf8'
+		);
+	});
+
+	test('static CSS targets current membership badge shapes on channel video cards', () => {
+		expect(generalCssContent).toContain(
+			"html[it-remove-member-only='true'] ytd-grid-video-renderer:has(badge-shape.yt-badge-shape--membership)"
+		);
+		expect(generalCssContent).toContain(
+			"html[it-remove-member-only='true'] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership)"
+		);
+		expect(generalCssContent).toContain(
+			"html[it-remove-member-only='true'] yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership)"
+		);
+	});
+
+	test('runtime injected CSS also hides lockup cards with membership badges', () => {
+		expect(generalJsContent).toContain(
+			'yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership)'
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- update the Remove member-only videos selectors for YouTube's current `badge-shape.yt-badge-shape--membership` markup
- cover grid, rich-item, and `yt-lockup-view-model` channel video card shapes
- keep the runtime-injected CSS in sync with the static selector coverage

Fixes #3862.

## Validation
- `npm ci --no-audit --no-fund --progress=false` - passed
- `npx jest tests/unit/member-only-hiding.test.js --runInBand` - 1 suite / 2 tests passed
- `npm run lint -- --quiet` - passed
- `git diff --cached --check` - passed
- `git diff --cached | gitleaks stdin --no-banner --redact` - no leaks found

## Limitations
- I did not run a live YouTube extension smoke test. I used selector regression coverage because the affected markup is external and the issue reports logged-out reproduction.
- `npm test -- tests/unit/member-only-hiding.test.js` currently invokes the repo's full `jest tests` script and hits a pre-existing `tests/unit/squared-thumbnails.test.js` `describe2` failure; the new focused test passes with direct Jest.