### PR TITLE
Fix Allow 60fps toggle without page reload

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -99,8 +99,8 @@ CODEC || 30FPS
 	Do not move, needs to be on top of first injected content
 	file to patch HTMLMediaElement before YT player uses it.
 --------------------------------------------------------------*/
-if (localStorage['it-codec'] || localStorage['it-player30fps']) {
-	function overwrite(self, callback, mime) {
+(function () {
+	function overwrite (self, callback, mime) {
 		if (localStorage['it-codec']) {
 			var re = new RegExp(localStorage['it-codec']);
 			// /webm|vp8|vp9|av01/
@@ -115,15 +115,21 @@ if (localStorage['it-codec'] || localStorage['it-player30fps']) {
 
 	if (window.MediaSource) {
 		var isTypeSupported = window.MediaSource.isTypeSupported;
-		window.MediaSource.isTypeSupported = function (mime) {
-			return overwrite(this, isTypeSupported, mime);
+		if (!isTypeSupported.itImprovedTubeCodecOverride) {
+			window.MediaSource.isTypeSupported = function (mime) {
+				return overwrite(this, isTypeSupported, mime);
+			}
+			window.MediaSource.isTypeSupported.itImprovedTubeCodecOverride = true;
 		}
 	}
 	var canPlayType = HTMLMediaElement.prototype.canPlayType;
-	HTMLMediaElement.prototype.canPlayType = function (mime) {
-		return overwrite(this, canPlayType, mime);
+	if (!canPlayType.itImprovedTubeCodecOverride) {
+		HTMLMediaElement.prototype.canPlayType = function (mime) {
+			return overwrite(this, canPlayType, mime);
+		}
+		HTMLMediaElement.prototype.canPlayType.itImprovedTubeCodecOverride = true;
 	}
-};
+})();
 
 /*--------------------------------------------------------------
 # MESSAGES

--- a/tests/unit/player-60fps-live-toggle.test.js
+++ b/tests/unit/player-60fps-live-toggle.test.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function getCodecHookSource () {
+	const filePath = path.join(__dirname, '../../js&css/web-accessible/core.js');
+	const coreContent = fs.readFileSync(filePath, 'utf8');
+	const marker = 'CODEC || 30FPS';
+	const markerIndex = coreContent.indexOf(marker);
+	const start = coreContent.indexOf('(function () {', markerIndex);
+	const end = coreContent.indexOf('})();', start) + '})();'.length;
+
+	return coreContent.slice(start, end);
+}
+
+function createSandbox () {
+	const localStorage = {};
+	const mediaSourceOriginal = jest.fn(() => true);
+	const canPlayTypeOriginal = jest.fn(() => 'probably');
+
+	function HTMLMediaElement () {}
+	HTMLMediaElement.prototype.canPlayType = canPlayTypeOriginal;
+
+	return {
+		localStorage,
+		window: {
+			MediaSource: {
+				isTypeSupported: mediaSourceOriginal
+			}
+		},
+		HTMLMediaElement,
+		mediaSourceOriginal,
+		canPlayTypeOriginal
+	};
+}
+
+describe('Codec and 30fps page-world hook', () => {
+	let codecHookSource;
+
+	beforeAll(() => {
+		codecHookSource = getCodecHookSource();
+	});
+
+	test('installs before cached settings exist and reacts when 30fps is enabled later', () => {
+		const sandbox = createSandbox();
+
+		vm.runInNewContext(codecHookSource, sandbox);
+
+		const highFrameRateMime = 'video/mp4; codecs="avc1.640028"; framerate=60';
+
+		expect(sandbox.window.MediaSource.isTypeSupported(highFrameRateMime)).toBe(true);
+		expect(sandbox.HTMLMediaElement.prototype.canPlayType(highFrameRateMime)).toBe('probably');
+
+		sandbox.localStorage['it-player30fps'] = true;
+
+		expect(sandbox.window.MediaSource.isTypeSupported(highFrameRateMime)).toBe('');
+		expect(sandbox.HTMLMediaElement.prototype.canPlayType(highFrameRateMime)).toBe('');
+
+		delete sandbox.localStorage['it-player30fps'];
+
+		expect(sandbox.window.MediaSource.isTypeSupported(highFrameRateMime)).toBe(true);
+		expect(sandbox.HTMLMediaElement.prototype.canPlayType(highFrameRateMime)).toBe('probably');
+	});
+
+	test('keeps codec blocking dynamic without wrapping repeatedly', () => {
+		const sandbox = createSandbox();
+		const vp9Mime = 'video/webm; codecs="vp09.00.10.08"; framerate=30';
+
+		vm.runInNewContext(codecHookSource, sandbox);
+		vm.runInNewContext(codecHookSource, sandbox);
+
+		sandbox.localStorage['it-codec'] = 'vp9|vp09';
+
+		expect(sandbox.window.MediaSource.isTypeSupported(vp9Mime)).toBe('');
+		expect(sandbox.HTMLMediaElement.prototype.canPlayType(vp9Mime)).toBe('');
+
+		delete sandbox.localStorage['it-codec'];
+
+		expect(sandbox.window.MediaSource.isTypeSupported(vp9Mime)).toBe(true);
+		expect(sandbox.mediaSourceOriginal).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- install the page-world codec/30fps hook even when cached settings are not present yet
- keep the hook reading `localStorage` dynamically so changing Allow 60fps to OFF takes effect without reloading YouTube
- guard the hook from wrapping `MediaSource.isTypeSupported` / `HTMLMediaElement.canPlayType` more than once

Fixes #1506

## Validation
- `npx jest tests/unit/player-60fps-live-toggle.test.js --runInBand`
- `npm test -- --runInBand` (fails only in existing `tests/unit/squared-thumbnails.test.js` because `describe2` is not defined; the new suite and the other 13 suites pass)
- `git diff --check`
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs tests/unit/player-60fps-live-toggle.test.js`

Note: linting `js&css/web-accessible/core.js` with the repo config still reports pre-existing issues outside this patch.