### PR TITLE
Fix video owner channel link after SPA navigation

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -394,6 +394,7 @@ ImprovedTube.getChannelUrlFromRenderer = function (renderer) {
 			data && data.navigationEndpoint,
 			data && data.endpoint,
 			runs && runs[0] && runs[0].navigationEndpoint,
+			data && data.title && data.title.runs && data.title.runs[0] && data.title.runs[0].navigationEndpoint,
 			data && data.ownerText && data.ownerText.runs && data.ownerText.runs[0] && data.ownerText.runs[0].navigationEndpoint,
 			data && data.shortBylineText && data.shortBylineText.runs && data.shortBylineText.runs[0] && data.shortBylineText.runs[0].navigationEndpoint
 		];

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -104,8 +104,7 @@ ImprovedTube.ytElementsHandler = function (node) {
 		this.improvedtubeYoutubeButtonsUnderPlayer();
 
 	} else if (name === 'YTD-VIDEO-SECONDARY-INFO-RENDERER') {
-		this.elements.yt_channel_name = node.querySelector('ytd-channel-name');
-		this.elements.yt_channel_link = node.querySelector('ytd-channel-name a');
+		this.refreshVideoOwnerElements(node);
 
 		if (document.documentElement.dataset.pageType === 'video') {
 			this.howLongAgoTheVideoWasUploaded();
@@ -328,6 +327,7 @@ ImprovedTube.videoPageUpdate = function () {
 
 		this.initialVideoUpdateDone = true;
 
+		ImprovedTube.refreshVideoOwnerElements();
 		ImprovedTube.howLongAgoTheVideoWasUploaded();
 		ImprovedTube.dayOfWeek();
 		ImprovedTube.exactUploadDate();
@@ -357,6 +357,81 @@ ImprovedTube.videoPageUpdate = function () {
 			if (typeof ImprovedTube.cleanupPlaylistHandlers === 'function') {
 				ImprovedTube.cleanupPlaylistHandlers();
 			}
+		}
+	}
+};
+
+ImprovedTube.getChannelUrlFromEndpoint = function (endpoint) {
+	if (!endpoint) {
+		return false;
+	}
+
+	var commandMetadata = endpoint.commandMetadata && endpoint.commandMetadata.webCommandMetadata,
+		browseEndpoint = endpoint.browseEndpoint,
+		url = (browseEndpoint && browseEndpoint.canonicalBaseUrl) || (commandMetadata && commandMetadata.url);
+
+	if (!url && browseEndpoint && browseEndpoint.browseId) {
+		url = '/channel/' + browseEndpoint.browseId;
+	}
+
+	if (url) {
+		try {
+			url = new URL(url, location.origin).href;
+		} catch (error) {}
+
+		if (this.regex.channel_link.test(url)) {
+			return url;
+		}
+	}
+
+	return false;
+};
+
+ImprovedTube.getChannelUrlFromRenderer = function (renderer) {
+	var data = renderer && ((renderer.__data && renderer.__data.data) || renderer.data),
+		runs = data && data.runs,
+		candidates = [
+			data && data.navigationEndpoint,
+			data && data.endpoint,
+			runs && runs[0] && runs[0].navigationEndpoint,
+			data && data.ownerText && data.ownerText.runs && data.ownerText.runs[0] && data.ownerText.runs[0].navigationEndpoint,
+			data && data.shortBylineText && data.shortBylineText.runs && data.shortBylineText.runs[0] && data.shortBylineText.runs[0].navigationEndpoint
+		];
+
+	for (var i = 0; i < candidates.length; i++) {
+		var url = this.getChannelUrlFromEndpoint(candidates[i]);
+
+		if (url) {
+			return url;
+		}
+	}
+
+	return false;
+};
+
+ImprovedTube.refreshVideoOwnerElements = function (root) {
+	var channelName = root && root.nodeName === 'YTD-CHANNEL-NAME'
+		? root
+		: root && root.querySelector && root.querySelector('ytd-channel-name');
+
+	if (!channelName) {
+		channelName = document.querySelector('#owner ytd-channel-name, #upload-info ytd-channel-name, ytd-watch-metadata ytd-channel-name, ytd-video-secondary-info-renderer ytd-channel-name');
+	}
+
+	if (channelName) {
+		this.elements.yt_channel_name = channelName;
+
+		var link = channelName.querySelector('a');
+
+		if (link) {
+			var url = this.getChannelUrlFromRenderer(channelName) || this.getChannelUrlFromRenderer(link);
+
+			if (url) {
+				link.href = url;
+			}
+
+			this.elements.yt_channel_link = link;
+			this.channelDefaultTab(link);
 		}
 	}
 };

--- a/tests/unit/video-owner-channel-link.test.js
+++ b/tests/unit/video-owner-channel-link.test.js
@@ -104,4 +104,24 @@ describe('Video owner channel link refresh (#1485)', () => {
 		expect(ImprovedTube.elements.yt_channel_link.href).toBe('https://www.youtube.com/@current');
 		expect(ImprovedTube.channelDefaultTab).toHaveBeenCalledWith(ImprovedTube.elements.yt_channel_link);
 	});
+
+	test('reads channel links from title renderer runs', () => {
+		channelName.__data = {
+			data: {
+				title: {
+					runs: [{
+						navigationEndpoint: {
+							browseEndpoint: {
+								canonicalBaseUrl: '/channel/UCcurrent'
+							}
+						}
+					}]
+				}
+			}
+		};
+
+		ImprovedTube.videoPageUpdate();
+
+		expect(ImprovedTube.elements.yt_channel_link.href).toBe('https://www.youtube.com/channel/UCcurrent');
+	});
 });

--- a/tests/unit/video-owner-channel-link.test.js
+++ b/tests/unit/video-owner-channel-link.test.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Video owner channel link refresh (#1485)', () => {
+	let channelName;
+	let link;
+
+	beforeEach(() => {
+		link = {
+			href: 'https://www.youtube.com/@previous/videos'
+		};
+		channelName = {
+			nodeName: 'YTD-CHANNEL-NAME',
+			querySelector: jest.fn(() => link),
+			__data: {
+				data: {
+					runs: [{
+						navigationEndpoint: {
+							commandMetadata: {
+								webCommandMetadata: {
+									url: '/@current'
+								}
+							},
+							browseEndpoint: {
+								canonicalBaseUrl: '/@current'
+							}
+						}
+					}]
+				}
+			}
+		};
+		global.document = {
+			documentElement: {
+				dataset: {
+					pageType: 'video'
+				}
+			},
+			querySelector: jest.fn(() => channelName)
+		};
+		global.location = {
+			href: 'https://www.youtube.com/watch?v=current-id',
+			origin: 'https://www.youtube.com'
+		};
+		global.ImprovedTube = {
+			elements: {},
+			storage: {},
+			regex: {
+				channel_link: /https:\/\/www.youtube.com\/@|((channel|user|c)\/)/,
+				channel_home_page: /\/@|((channel|user|c)\/)[^/]+(\/featured)?\/?$/,
+				channel_home_page_postfix: /\/(featured)?\/?$/
+			},
+			channelDefaultTab: jest.fn(),
+			getParam: jest.fn((query, name) => name === 'v' ? 'video-id' : false),
+			howLongAgoTheVideoWasUploaded: jest.fn(),
+			dayOfWeek: jest.fn(),
+			exactUploadDate: jest.fn(),
+			channelVideosCount: jest.fn(),
+			upNextAutoplay: jest.fn(),
+			playerAutofullscreen: jest.fn(),
+			playerSize: jest.fn(),
+			playerPlaybackSpeedButton: jest.fn(),
+			playerScreenshotButton: jest.fn(),
+			addYouTubeReturnButton: jest.fn(),
+			playerRepeatButton: jest.fn(),
+			playerRotateButton: jest.fn(),
+			playerPopupButton: jest.fn(),
+			playerFitToWinButton: jest.fn(),
+			playerRewindAndForwardButtons: jest.fn(),
+			playerIncreaseDecreaseSpeedButtons: jest.fn(),
+			playerCinemaModeButton: jest.fn(),
+			playerHamburgerButton: jest.fn(),
+			playerControls: jest.fn(),
+			playlistLargePlaylistHandler: jest.fn(),
+			cleanupPlaylistHandlers: jest.fn(),
+			messages: {
+				send: jest.fn()
+			}
+		};
+
+		const functionsPath = path.join(__dirname, '../../js&css/web-accessible/functions.js');
+		const functionsContent = fs.readFileSync(functionsPath, 'utf8');
+		const start = functionsContent.indexOf('ImprovedTube.videoPageUpdate = function ()');
+		const end = functionsContent.indexOf('ImprovedTube.playerOnPlay = function ()');
+
+		vm.runInNewContext(functionsContent.slice(start, end), {
+			ImprovedTube: global.ImprovedTube,
+			document: global.document,
+			location: global.location,
+			URL: URL
+		});
+	});
+
+	afterEach(() => {
+		delete global.ImprovedTube;
+		delete global.document;
+		delete global.location;
+	});
+
+	test('uses the current renderer endpoint when YouTube reuses the owner link node', () => {
+		ImprovedTube.videoPageUpdate();
+
+		expect(ImprovedTube.elements.yt_channel_name).toBe(channelName);
+		expect(ImprovedTube.elements.yt_channel_link.href).toBe('https://www.youtube.com/@current');
+		expect(ImprovedTube.channelDefaultTab).toHaveBeenCalledWith(ImprovedTube.elements.yt_channel_link);
+	});
+});


### PR DESCRIPTION
## Summary
- refresh the cached watch-page owner channel elements during video page updates
- restore the current owner link from YouTube renderer endpoint data before applying the default channel tab rewrite
- add a regression test for reused owner link nodes retaining a previous channel URL

Fixes #1485

## Tests
- `npm ci`
- `npx jest tests/unit/video-owner-channel-link.test.js --runInBand`
- `npx jest tests/unit/watch-later-buttons.test.js tests/unit/popup-preview-button.test.js tests/unit/remaining-duration.test.js tests/unit/video-owner-channel-link.test.js --runInBand`
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs tests/unit/video-owner-channel-link.test.js`
- `node --check js&css/web-accessible/functions.js && node --check tests/unit/video-owner-channel-link.test.js`
- `git diff --check`

Note: running ESLint over the full existing `js&css/web-accessible/functions.js` still reports pre-existing style issues outside this patch.