### PR TITLE
Fix Firefox settings import persistence

### DIFF
--- a/menu/functions.js
+++ b/menu/functions.js
@@ -123,6 +123,32 @@ extension.exportSettings = function () {
 # IMPORT SETTINGS
 --------------------------------------------------------------*/
 
+extension.applyImportedSettings = function (data, callback) {
+	if (!data || typeof data !== 'object' || Array.isArray(data)) {
+		return;
+	}
+
+	if (!satus.storage.data || typeof satus.storage.data !== 'object') {
+		satus.storage.data = {};
+	}
+
+	for (var key in data) {
+		satus.storage.data[key] = data[key];
+	}
+
+	chrome.storage.local.set(data, function () {
+		if (chrome.runtime.lastError) {
+			console.error(chrome.runtime.lastError);
+
+			return;
+		}
+
+		satus.events.trigger('storage-set');
+
+		if (callback) callback();
+	});
+};
+
 extension.importSettings = function () {
 	if (location.href.indexOf('action=import-settings') !== -1) {
 		satus.render({
@@ -152,20 +178,21 @@ extension.importSettings = function () {
 								var file_reader = new FileReader();
 
 								file_reader.onload = function () {
-									var data = JSON.parse(this.result);
-									for (var key in data) {
-										satus.storage.set(key, data[key]);
-									}
+									try {
+										var data = JSON.parse(this.result);
 
-									setTimeout(function () {
-										chrome.runtime.sendMessage({
-											action: 'import-settings'
+										extension.applyImportedSettings(data, function () {
+											chrome.runtime.sendMessage({
+												action: 'import-settings'
+											});
+
+											setTimeout(function () {
+												close();
+											}, 128);
 										});
-
-										setTimeout(function () {
-											close();
-										}, 128);
-									}, 256);
+									} catch (error) {
+										console.error(error);
+									}
 								};
 
 								file_reader.readAsText(this.files[0]);
@@ -240,13 +267,23 @@ extension.pullSettings = function () {
 				text: 'ok',
 				on: {
 					click: function () {
+						var modalProvider = this.modalProvider;
+
 						chrome.storage.sync.get('settings', function (r) {
-							var data = JSON.parse(r['settings']);
-							for (var key in data) {
-								satus.storage.set(key, data[key]);
+							try {
+								var data = JSON.parse(r['settings']);
+
+								extension.applyImportedSettings(data, function () {
+									chrome.runtime.sendMessage({
+										action: 'import-settings'
+									});
+
+									modalProvider.close();
+								});
+							} catch (error) {
+								console.error(error);
 							}
 						});
-						this.modalProvider.close();
 					}
 				}
 			}

--- a/tests/unit/import-settings.test.js
+++ b/tests/unit/import-settings.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Settings import persistence', () => {
+	let context;
+	let callback;
+
+	beforeEach(() => {
+		callback = undefined;
+		context = {
+			extension: {},
+			location: {
+				href: ''
+			},
+			navigator: {
+				userAgent: 'Firefox'
+			},
+			console: {
+				error: jest.fn()
+			},
+			chrome: {
+				runtime: {},
+				storage: {
+					local: {
+						set: jest.fn((_data, done) => {
+							callback = done;
+						})
+					}
+				}
+			},
+			satus: {
+				storage: {
+					data: {},
+					get: jest.fn(),
+					set: jest.fn()
+				},
+				events: {
+					trigger: jest.fn()
+				},
+				render: jest.fn(),
+				isset: jest.fn(value => value !== undefined && value !== null)
+			}
+		};
+
+		const filePath = path.join(__dirname, '../../menu/functions.js');
+		const source = fs.readFileSync(filePath, 'utf8');
+
+		vm.runInNewContext(source, context);
+	});
+
+	test('writes imported settings in one storage transaction', () => {
+		const imported = {
+			watched: {
+				video1: {
+					title: 'First video'
+				},
+				video2: {
+					title: 'Second video'
+				}
+			},
+			shortcut_play_pause: {
+				keys: {
+					code: 'Numpad5'
+				}
+			}
+		};
+		const done = jest.fn();
+
+		context.extension.applyImportedSettings(imported, done);
+
+		expect(context.satus.storage.set).not.toHaveBeenCalled();
+		expect(context.chrome.storage.local.set).toHaveBeenCalledTimes(1);
+		expect(context.chrome.storage.local.set).toHaveBeenCalledWith(imported, expect.any(Function));
+		expect(context.satus.storage.data).toEqual(imported);
+		expect(done).not.toHaveBeenCalled();
+
+		callback();
+
+		expect(context.satus.events.trigger).toHaveBeenCalledWith('storage-set');
+		expect(done).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not write invalid import payloads', () => {
+		context.extension.applyImportedSettings(null);
+		context.extension.applyImportedSettings([]);
+
+		expect(context.chrome.storage.local.set).not.toHaveBeenCalled();
+		expect(context.satus.storage.data).toEqual({});
+	});
+});


### PR DESCRIPTION
## Summary
- import settings in a single `chrome.storage.local.set` transaction instead of many async per-key writes
- wait for the storage callback before notifying tabs or closing the import window
- reuse the same import persistence helper for synced settings pulls

## Tests
- `npx jest tests/unit/import-settings.test.js --runInBand`
- `npx jest tests/unit/import-settings.test.js tests/unit/themes-menu.test.js tests/unit/watch-later-buttons.test.js --runInBand`
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs menu/functions.js tests/unit/import-settings.test.js`
- `node --check menu/functions.js && node --check tests/unit/import-settings.test.js && git diff --check`

Fixes #1330