### PR TITLE
Fix full-window player gap with hover header

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -393,6 +393,20 @@ html[data-page-type=video][it-header-position=hover_on_video_page] ytd-app:not([
 	margin-top: 14px;
 }
 
+html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]),
+html[data-page-type=video][it-player-size='fit_to_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) {
+	--it-header-size: 0px;
+}
+
+html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) ytd-app:not([player-fullscreen_]) ytd-watch-flexy:not([fullscreen]),
+html[data-page-type=video][it-player-size='fit_to_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) ytd-app:not([player-fullscreen_]) ytd-watch-flexy:not([fullscreen]),
+html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) ytd-app:not([player-fullscreen_]) ytd-watch-flexy:not([fullscreen]) .player-theater-container,
+html[data-page-type=video][it-player-size='fit_to_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) ytd-app:not([player-fullscreen_]) ytd-watch-flexy:not([fullscreen]) .player-theater-container,
+html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) div#page #movie_player:not(.it-mini-player):not(.ytp-fullscreen),
+html[data-page-type=video][it-player-size='fit_to_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) div#page #movie_player:not(.it-mini-player):not(.ytp-fullscreen) {
+	margin-top: 0 !important;
+}
+
  /*--------------------------------------------------------------
 # FIXED PLAYER SIZE
 --------------------------------------------------------------*/

--- a/tests/unit/header-hover-player-gap.test.js
+++ b/tests/unit/header-hover-player-gap.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Video hover header player sizing', () => {
+	let playerCss;
+
+	beforeAll(() => {
+		playerCss = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/player/player.css'), 'utf8');
+	});
+
+	test('does not reserve header height for full-window hover header layouts', () => {
+		expect(playerCss).toContain("html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page])");
+		expect(playerCss).toContain("html[data-page-type=video][it-player-size='fit_to_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page])");
+		expect(playerCss).toContain('--it-header-size: 0px;');
+	});
+
+	test('clears hover header top margins from full-window player containers', () => {
+		expect(playerCss).toContain("html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) ytd-app:not([player-fullscreen_]) ytd-watch-flexy:not([fullscreen])");
+		expect(playerCss).toContain("html[data-page-type=video][it-player-size='full_window']:is([it-header-position=hover], [it-header-position=hover_on_video_page]) div#page #movie_player:not(.it-mini-player):not(.ytp-fullscreen)");
+		expect(playerCss).toContain('margin-top: 0 !important;');
+	});
+});


### PR DESCRIPTION
## Summary
- stop reserving header height for full-window / fit-to-window player layouts when the video-page header is set to hover
- clear the hover-header top margins from the watch flexy, theater container, and movie player so the video can use the full viewport height
- add CSS regression coverage for the hover-header full-window layout

## Tests
- `npx jest tests/unit/header-hover-player-gap.test.js --runInBand`
- `npx jest tests/unit/header-hover-player-gap.test.js tests/unit/remaining-duration.test.js tests/unit/themes-menu.test.js --runInBand`
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs tests/unit/header-hover-player-gap.test.js`
- `node --check tests/unit/header-hover-player-gap.test.js && git diff --check`

Fixes #1823