### PR TITLE
Fix classic description modes

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/details/details.css
+++ b/js&css/extension/www.youtube.com/appearance/details/details.css
@@ -157,6 +157,19 @@ html[it-description='hidden'] ytd-video-secondary-info-renderer ytd-expander.ytd
 html[it-description='hidden'] div#action-panel-details,
 html[it-description='hidden'] ytd-expander.ytd-video-secondary-info-renderer,
 html[it-description='hidden'] #description-inline-expander,
+html[it-description='classic'] ytd-watch-metadata > #above-the-fold > #title,
+html[it-description='classic'] ytd-watch-metadata > #above-the-fold > #top-row,
+html[it-description='classic'] ytd-watch-metadata > #above-the-fold > #middle-row,
+html[it-description='classic'] ytd-watch-metadata ytd-watch-info-text,
+html[it-description='classic_expanded'] ytd-watch-metadata > #above-the-fold > #title,
+html[it-description='classic_expanded'] ytd-watch-metadata > #above-the-fold > #top-row,
+html[it-description='classic_expanded'] ytd-watch-metadata > #above-the-fold > #middle-row,
+html[it-description='classic_expanded'] ytd-watch-metadata ytd-watch-info-text,
+html[it-description='classic_hidden'] ytd-watch-metadata > #above-the-fold > #title,
+html[it-description='classic_hidden'] ytd-watch-metadata > #above-the-fold > #top-row,
+html[it-description='classic_hidden'] ytd-watch-metadata > #above-the-fold > #middle-row,
+html[it-description='classic_hidden'] ytd-watch-metadata > #above-the-fold > #bottom-row,
+html[it-description='classic_hidden'] ytd-watch-metadata #description,
 /*----->>> FOOTER: # Hide --------*/
 html[it-popup-ad='true'] ytd-guide-renderer #footer,
 html[it-popup-ad='true'] yt-mealbar-promo-renderer  
@@ -185,30 +198,47 @@ html[it-hide-save-button='icons_only'] tp-yt-paper-listbox tp-yt-paper-item:has(
 html[it-hide-report-button='icons_only'] tp-yt-paper-listbox tp-yt-paper-item:has(svg path[d^="m4 2.999-.146.073A1.55"]) yt-icon
  /*=================================*/
     	{margin-right: 4px !important;}
-/*  Dated:
-html[it-description='classic'] .ytd-watch-flexy #info-contents, 
-html[it-description='classic'] .ytd-watch-flexy #meta-contents { display: block !important; } 
-html[it-description='classic'] #below.ytd-watch-flexy { top:-20px; }
-html[it-description='classic'] ytd-menu-renderer[has-flexible-items] { overflow-y: unset !important; }
-html[it-description='classic'] ytd-video-primary-info-renderer { padding-bottom: 14px !important; }
 
+html[it-description='classic'] .ytd-watch-flexy #info-contents,
+html[it-description='classic'] .ytd-watch-flexy #meta-contents,
 html[it-description='classic_expanded'] .ytd-watch-flexy #info-contents,
-html[it-description='classic_expanded'] .ytd-watch-flexy #meta-contents { display: block !important; } 
-html[it-description='classic_expanded'] #below.ytd-watch-flexy { top:-20px; }
-html[it-description='classic_expanded'] ytd-menu-renderer[has-flexible-items] { overflow-y: unset !important; }
-html[it-description='classic_expanded'] ytd-video-primary-info-renderer { padding-bottom: 14px !important; }
+html[it-description='classic_expanded'] .ytd-watch-flexy #meta-contents,
+html[it-description='classic_hidden'] .ytd-watch-flexy #info-contents {
+	display: block !important;
+}
 
-html[it-description='classic_hidden'] .ytd-watch-flexy #info-contents { display: block !important; } 
+html[it-description='classic'] #below.ytd-watch-flexy,
+html[it-description='classic_expanded'] #below.ytd-watch-flexy,
 html[it-description='classic_hidden'] #below.ytd-watch-flexy { top:-20px; }
+
+html[it-description='classic'] ytd-menu-renderer[has-flexible-items],
+html[it-description='classic_expanded'] ytd-menu-renderer[has-flexible-items],
 html[it-description='classic_hidden'] ytd-menu-renderer[has-flexible-items] { overflow-y: unset !important; }
+
+html[it-description='classic'] ytd-video-primary-info-renderer,
+html[it-description='classic_expanded'] ytd-video-primary-info-renderer,
 html[it-description='classic_hidden'] ytd-video-primary-info-renderer { padding-bottom: 14px !important; }
 
-html[it-description='classic'] div.style-scope.ytd-watch-flexy + ytd-watch-metadata,
-html[it-description='classic_expanded'] div.style-scope.ytd-watch-flexy + ytd-watch-metadata,
-html[it-description='classic_hidden'] div.style-scope.ytd-watch-flexy + ytd-watch-metadata {
+html[it-description='classic'] ytd-watch-metadata #description,
+html[it-description='classic_expanded'] ytd-watch-metadata #description {
+	margin-top: 8px !important;
+}
+
+html[it-description='classic'] ytd-watch-metadata #description-inner,
+html[it-description='classic_expanded'] ytd-watch-metadata #description-inner {
+	margin: 0 !important;
+}
+
+html[it-description='classic'] ytd-watch-metadata #description-inline-expander,
+html[it-description='classic_expanded'] ytd-watch-metadata #description-inline-expander {
+	overflow: visible !important;
+}
+
+html[it-description='classic'] ytd-watch-metadata #description-interaction,
+html[it-description='classic_expanded'] ytd-watch-metadata #description-interaction {
 	display: none !important;
 }
-*/
+
 /*--------------------------------------------------------------
 # SHOW EXACT UPLOAD DATE
 --------------------------------------------------------------*/

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -263,9 +263,9 @@ document.addEventListener('it-message-from-extension', function () {
 					break
 
 				case 'description':
-					if (ImprovedTube.storage.description === "expanded") {
+					if (ImprovedTube.storage.description === "expanded" || ImprovedTube.storage.description === "classic_expanded") {
 						try { document.querySelector("#more").click() || document.querySelector("#expand").click(); } catch { }
-					} else if (ImprovedTube.storage.description === "normal") {
+					} else if (ImprovedTube.storage.description === "normal" || ImprovedTube.storage.description === "classic") {
 						try { document.querySelector("#less").click() || document.querySelector("#collapse").click(); } catch { }
 					}
 					break

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -619,7 +619,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
  EXPAND DESCRIPTION
 ------------------------------------------------------------------------------*/
 ImprovedTube.expandDescription = function (el) {
-	if (this.storage.description === "expanded") {
+	if (this.storage.description === "expanded" || this.storage.description === "classic_expanded") {
 		if (!ImprovedTube.originalFocus) { ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
 		ImprovedTube.forbidFocus =  function (ms) { 
 			HTMLElement.prototype.focus = function() {console.log("Preventing YouTube's scripted scrolling for a moment."); }

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -644,16 +644,16 @@ extension.skeleton.main.layers.section.appearance.on.click.description = {
 	}, {
 		text: "hidden",
 		value: "hidden"
-	}/*, {
-					text: "Classic",
-					value: "classic"
-				}, {
-					text: "Classic expanded",
-					value: "classic_expanded"
-				}, {
-					text: "Classic hidden",
-					value: "classic_hidden"
-				}*/],
+	}, {
+		text: "Classic",
+		value: "classic"
+	}, {
+		text: "Classic expanded",
+		value: "classic_expanded"
+	}, {
+		text: "Classic hidden",
+		value: "classic_hidden"
+	}],
 	tags: "hide,remove"
 };
 

--- a/tests/unit/classic-description.test.js
+++ b/tests/unit/classic-description.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Classic description options (#1802)', () => {
+	let detailsCss;
+	let appearanceMenu;
+	let appearanceJs;
+	let coreJs;
+
+	beforeAll(() => {
+		detailsCss = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/details/details.css'), 'utf8');
+		appearanceMenu = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/appearance.js'), 'utf8');
+		appearanceJs = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/appearance.js'), 'utf8');
+		coreJs = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/core.js'), 'utf8');
+	});
+
+	test('restores the three Classic choices in the description menu', () => {
+		expect(appearanceMenu).toContain('value: "classic"');
+		expect(appearanceMenu).toContain('value: "classic_expanded"');
+		expect(appearanceMenu).toContain('value: "classic_hidden"');
+	});
+
+	test('keeps the current YouTube description visible for Classic modes', () => {
+		expect(detailsCss).toContain("html[it-description='classic'] ytd-watch-metadata #description");
+		expect(detailsCss).toContain("html[it-description='classic_expanded'] ytd-watch-metadata #description");
+		expect(detailsCss).toContain("html[it-description='classic'] ytd-watch-metadata #description-inline-expander");
+		expect(detailsCss).toContain("html[it-description='classic_expanded'] ytd-watch-metadata #description-inline-expander");
+		expect(detailsCss).toContain("html[it-description='classic'] ytd-watch-metadata > #above-the-fold > #title");
+		expect(detailsCss).toContain("html[it-description='classic_expanded'] ytd-watch-metadata > #above-the-fold > #top-row");
+		expect(detailsCss).toContain("html[it-description='classic'] ytd-watch-metadata ytd-watch-info-text");
+		expect(detailsCss).toContain("html[it-description='classic_expanded'] ytd-watch-metadata ytd-watch-info-text");
+		expect(detailsCss).not.toContain("html[it-description='classic'] div.style-scope.ytd-watch-flexy + ytd-watch-metadata");
+	});
+
+	test('hides the current YouTube description for Classic hidden', () => {
+		expect(detailsCss).toContain("html[it-description='classic_hidden'] ytd-watch-metadata > #above-the-fold > #bottom-row");
+		expect(detailsCss).toContain("html[it-description='classic_hidden'] ytd-watch-metadata #description");
+	});
+
+	test('expands descriptions for Classic expanded', () => {
+		expect(appearanceJs).toContain('this.storage.description === "expanded" || this.storage.description === "classic_expanded"');
+		expect(coreJs).toContain('ImprovedTube.storage.description === "expanded" || ImprovedTube.storage.description === "classic_expanded"');
+	});
+
+	test('collapses descriptions for Classic normal mode', () => {
+		expect(coreJs).toContain('ImprovedTube.storage.description === "normal" || ImprovedTube.storage.description === "classic"');
+	});
+});


### PR DESCRIPTION
## Summary
- restore the Classic, Classic expanded, and Classic hidden choices in the Description menu
- adapt the classic description CSS to YouTube's current watch metadata DOM instead of hiding the new description container
- make Classic expanded use the existing automatic expand behavior, and Classic collapse when switching back

Fixes #1802.

## Tests
- npx jest tests/unit/classic-description.test.js tests/unit/join-button-hiding.test.js tests/unit/remaining-duration.test.js tests/unit/themes-menu.test.js --runInBand
- node --check js&css/web-accessible/www.youtube.com/appearance.js && node --check js&css/web-accessible/core.js && node --check menu/skeleton-parts/appearance.js && node --check tests/unit/classic-description.test.js && git diff --check
- ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs tests/unit/classic-description.test.js

Note: running the shared ESLint config against js&css/web-accessible/core.js or js&css/web-accessible/www.youtube.com/appearance.js still reports existing baseline style errors on origin/master, so I limited the lint check to the new test file.