### PR TITLE
Add subscription live stream filter

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -116,6 +116,9 @@
   "atSubscriptions": {
     "message": "at 'Subscriptions'"
   },
+  "removeSubscriptionsLiveStreams": {
+    "message": "Hide live streams at 'Subscriptions'"
+  },
   "atTrending": {
     "message": "at 'Trending'"
   },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -157,6 +157,21 @@ html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-reel-sh
 html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="SHORTS"]),
 html[it-pathname='/feed/history'][it-remove-history-shorts="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="SHORTS"]),
 /*--------------------------------------------------------------
+# REMOVE SUBSCRIPTION LIVE STREAMS
+--------------------------------------------------------------*/
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="LIVE"]),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(.badge-style-type-live-now),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--live-now),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--upcoming-event),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="LIVE"]),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"]),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(.badge-style-type-live-now),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(badge-shape.yt-badge-shape--live-now),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(badge-shape.yt-badge-shape--upcoming-event),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] yt-lockup-view-model:has(badge-shape.yt-badge-shape--live-now),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-live-streams="true"] yt-lockup-view-model:has(badge-shape.yt-badge-shape--upcoming-event),
+/*--------------------------------------------------------------
 # REMOVE PLAYABLES
 --------------------------------------------------------------*/
 html[it-pathname='/'][it-remove-playables="true"] ytd-rich-section-renderer:has(ytd-mini-game-card-view-model) {

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -78,6 +78,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'atSubscriptions',
 					id: 'remove-subscriptions-shorts'
 				},
+				remove_subscriptions_live_streams: {
+					component: 'switch',
+					text: 'removeSubscriptionsLiveStreams',
+					id: 'remove-subscriptions-live-streams'
+				},
 				remove_trending_shorts: {
 					component: 'switch',
 					text: 'atTrending'

--- a/tests/unit/subscriptions-live-streams.test.js
+++ b/tests/unit/subscriptions-live-streams.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Subscription live stream hiding (#1584)', () => {
+	let generalCssContent;
+	let generalSkeletonContent;
+	let englishMessages;
+
+	beforeAll(() => {
+		generalCssContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/extension/www.youtube.com/general/general.css'),
+			'utf8'
+		);
+		generalSkeletonContent = fs.readFileSync(
+			path.join(__dirname, '../../menu/skeleton-parts/general.js'),
+			'utf8'
+		);
+		englishMessages = fs.readFileSync(
+			path.join(__dirname, '../../_locales/en/messages.json'),
+			'utf8'
+		);
+	});
+
+	test('adds a dedicated subscriptions live stream setting', () => {
+		expect(generalSkeletonContent).toContain('remove_subscriptions_live_streams');
+		expect(generalSkeletonContent).toContain("text: 'removeSubscriptionsLiveStreams'");
+		expect(englishMessages).toContain('"removeSubscriptionsLiveStreams"');
+	});
+
+	test('hides current and upcoming subscription live stream cards', () => {
+		expect(generalCssContent).toContain(
+			'html[it-pathname=\'/feed/subscriptions\'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="LIVE"])'
+		);
+		expect(generalCssContent).toContain(
+			'html[it-pathname=\'/feed/subscriptions\'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="UPCOMING"])'
+		);
+		expect(generalCssContent).toContain(
+			'html[it-pathname=\'/feed/subscriptions\'][it-remove-subscriptions-live-streams="true"] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--live-now)'
+		);
+		expect(generalCssContent).toContain(
+			'html[it-pathname=\'/feed/subscriptions\'][it-remove-subscriptions-live-streams="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="LIVE"])'
+		);
+		expect(generalCssContent).toContain(
+			'html[it-pathname=\'/feed/subscriptions\'][it-remove-subscriptions-live-streams="true"] yt-lockup-view-model:has(badge-shape.yt-badge-shape--live-now)'
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1584

## Summary
- add a dedicated "Hide live streams at 'Subscriptions'" setting next to the existing subscriptions Shorts filter
- hide live/upcoming stream subscription cards across current YouTube renderers (`ytd-rich-item-renderer`, `ytd-video-renderer`, `yt-lockup-view-model`)
- add static unit coverage for the setting, locale key, and CSS selectors

## Verification
- `node --check menu/skeleton-parts/general.js`
- `node --check tests/unit/subscriptions-live-streams.test.js`
- static check for locale/skeleton/CSS wiring
- `git diff --check`

Note: I could not run the Jest test command because this environment does not have dependencies installed (`jest: command not found`), and installing npm dependencies from the registry was blocked by local policy.