### PR TITLE
feat: include channel name in screenshot filename

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -790,7 +790,9 @@ ImprovedTube.screenshot = function () {
 		} else {
 			let a = document.createElement('a');
 			a.href = URL.createObjectURL(blob);
-			a.download = (ImprovedTube.videoId() || location.href.match) + ' ' + new Date(ImprovedTube.elements.player.getCurrentTime() * 1000).toISOString().substr(11, 8).replace(/:/g, '-') + ' ' + ImprovedTube.videoTitle() + (subText ? ' - ' + subText.trim() : '') + '.png';
+			const channelNameEl = document.querySelector('.ytd-channel-name a') || document.querySelector('#upload-info .ytd-channel-name');
+			const channelName = channelNameEl ? channelNameEl.textContent.trim() : '';
+			a.download = (ImprovedTube.videoId() || location.href.match) + ' ' + new Date(ImprovedTube.elements.player.getCurrentTime() * 1000).toISOString().substr(11, 8).replace(/:/g, '-') + (channelName ? ' ' + channelName : '') + ' ' + ImprovedTube.videoTitle() + (subText ? ' - ' + subText.trim() : '') + '.png';
 			a.click();
 			console.log("ImprovedTube: Screeeeeeenshot tada!");
 		}


### PR DESCRIPTION
## Summary

Closes #3854.

- Reads the channel name from the page using the `.ytd-channel-name a` selector (with `#upload-info .ytd-channel-name` as a fallback) — the same selectors already used elsewhere in `player.js`
- Appends the channel name between the timestamp and video title in the screenshot filename
- Falls back gracefully (channel name simply omitted) if the element is not found on the page

**Before:** `{videoId} {timestamp} {videoTitle}.png`
**After:** `{videoId} {timestamp} {channelName} {videoTitle}.png`